### PR TITLE
Fix roadmap link in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,5 +13,5 @@ This is a package (work-in-progress) rework the Lie group featues of [`Manifolds
 This especially also includes a few different choices in default behabiour that
 is different from the `Manifolds.jl` one. For purely manifold-based operations, any Lie group still is “build upon” a Riemannian manifold.
 
-See [#1](https://github.com/JuliaManifolds/LieGroups.jl/issues/1) for an overview of fatures that are plannned.
+See [#5](https://github.com/JuliaManifolds/LieGroups.jl/issues/5) for an overview of fatures that are plannned.
 Feel free to add to this list with opening further issues.


### PR DESCRIPTION
This is probably an artifact from transferring all issues from the other repository.