### PR TITLE
Add a ValidationLieGroup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ Everything denoted by “formerly” refers to the previous name in [`Manifolds.
   * `ProductLieGroup` (formerly `ProductGroup`)
   * `RightSemidirectProductLieGroup`
   * `⋊` (alias for `RightSemidirectProductGroupOperation` when a `default_right_action(G,H)` is defined for the two groups)
+  * a `ValidationLieGroup` verifying input and output of all interface functions, similar to the [`ValidationManifold`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/manifolds/#A-manifold-for-validation) which can also be used internally.
 * `AbstractGroupOperation` as well as its concrete subtypes
   * `AdditionGroupOperation` (formerly `AdditionOperation`)
   * `MatrixMultiplicationGroupOperation` (formerly `MultiplicationOperation`)

--- a/Readme.md
+++ b/Readme.md
@@ -5,17 +5,29 @@
     </picture>
 </div>
 
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliamanifolds.github.io/LieGroups.jl/stable/)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliamanifolds.github.io/LieGroups.jl/dev/)
-[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle) [![CI](https://github.com/JuliaManifolds/LieGroups.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaManifolds/LieGroups.jl/actions?query=workflow%3ACI+branch%3Amain) [![codecov.io](http://codecov.io/github/JuliaManifolds/LieGroups.jl/coverage.svg?branch=main)](https://codecov.io/gh/JuliaManifolds/LieGroups.jl/)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle) [![CI](https://github.com/JuliaManifolds/LieGroups.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaManifolds/LieGroups.jl/actions?query=workflow%3ACI+branch%3Amain)
+[![codecov](https://codecov.io/gh/JuliaManifolds/LieGroups.jl/graph/badge.svg?token=32odCSyJX5)](https://codecov.io/gh/JuliaManifolds/LieGroups.jl)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-This is a package to rework the Lie group features of [`Manifolds.jl`](https://juliamanifolds.github.io/Manifolds.jl/stable/) in a unified way into a separate package.
+This package is a rework of the Lie group features of [`Manifolds.jl`](https://juliamanifolds.github.io/Manifolds.jl/stable/) in a unified way into a separate package. It especially puts more focus on the Lie group defaults and handling the corresponding Lie algebra.
+
+## Installation
+
+In Julia you can install this package by typing
+
+```julia
+using Pkg; Pkg.add("LieGroups")
+```
+
+in the Julia REPL.
 
 > [!NOTE]
 > Since this is a rework of the features from [`Manifolds.jl`](https://juliamanifolds.github.io/Manifolds.jl/stable/), both `LieGroups.jl` and `Manifolds.jl` 0.10 export a few types of same name, for example `Identity`.
 While `LieGroups.jl` depends on `Manifolds.jl`, it is not recommended to load both into the same namespace, that is, doing `using Manifolds.jl, LieGroups.jl`, since then these conflicts might lead to unforeseen errors, where you would need to specify the namespace to resolve this ambiguity.
 > See [transition from Manifolds.jl](https://juliamanifolds.github.io/LieGroups.jl/stable/tutorials/transition-from-manifoldsjl.html) for a comprehensive list.
-
-This especially also includes a few different choices in default behaviour that
+> This especially also includes a few different choices in default behaviour that
 is different from the [`Manifolds.jl`](https://juliamanifolds.github.io/Manifolds.jl/stable/) one. For purely manifold-based operations, any Lie group still is “build upon” a Riemannian manifold.
 
 See [#5](https://github.com/JuliaManifolds/LieGroups.jl/issues/5) for an overview of features that we plan to implement.

--- a/docs/src/interface/group.md
+++ b/docs/src/interface/group.md
@@ -21,6 +21,19 @@ LieGroups.CommonUnitarySubAlgebra
 LieGroups.@default_lie_group_fallbacks
 ```
 
+## A validation Lie group
+
+```@docs
+ValidationLieGroup
+```
+
+### Internal functions
+
+```@docs
+LieGroups._vLc
+LieGroups._msg
+```
+
 ## Literature
 
 ```@bibliography

--- a/docs/src/interface/group.md
+++ b/docs/src/interface/group.md
@@ -1,6 +1,7 @@
 # An interface for Lie groups
 
 ```@docs
+AbstractLieGroup
 LieGroup
 AbstractLieAlgebraTangentVector
 AbstractLieGroupPoint

--- a/src/LieGroups.jl
+++ b/src/LieGroups.jl
@@ -97,6 +97,7 @@ export UnitaryGroup
 export AbstractLieGroupPoint, AbstractLieAlgebraTangentVector
 export SpecialEuclideanMatrixPoint, SpecialEuclideanMatrixTangentVector
 export SpecialEuclideanProductPoint, SpecialEuclideanProductTangentVector
+export ValidationMPoint, ValidationLieAlgebraTangentVector
 
 # Errors
 export CompositeManifoldError

--- a/src/LieGroups.jl
+++ b/src/LieGroups.jl
@@ -61,6 +61,7 @@ export AbstractLieGroup
 export LieGroup, LieAlgebra
 export PowerLieGroup, ProductLieGroup
 export LeftSemidirectProductLieGroup, RightSemidirectProductLieGroup
+export ValidationLieGroup
 export DefaultLieAlgebraOrthogonalBasis
 export ×, ^, ⋉, ⋊
 #

--- a/src/LieGroups.jl
+++ b/src/LieGroups.jl
@@ -14,7 +14,7 @@ using LinearAlgebra, ManifoldsBase, Manifolds, StaticArrays, Random
 
 import LinearAlgebra: adjoint, adjoint!
 
-using ManifoldsBase: RealNumbers, ComplexNumbers, ℝ, ℂ
+using ManifoldsBase: RealNumbers, ComplexNumbers, ℝ, ℂ, internal_value
 
 #
 #

--- a/src/LieGroups.jl
+++ b/src/LieGroups.jl
@@ -41,7 +41,7 @@ include("group_actions/group_operation_action.jl")
 include("groups/power_group.jl")
 include("groups/product_group.jl")
 include("groups/semidirect_product_group.jl")
-
+include("groups/validation_group.jl")
 # Lie groups
 
 include("groups/translation_group.jl")
@@ -57,6 +57,7 @@ include("groups/special_orthogonal_group.jl")
 # Products of Groups
 include("groups/special_euclidean_group.jl")
 
+export AbstractLieGroup
 export LieGroup, LieAlgebra
 export PowerLieGroup, ProductLieGroup
 export LeftSemidirectProductLieGroup, RightSemidirectProductLieGroup

--- a/src/Lie_algebra/Lie_algebra_interface.jl
+++ b/src/Lie_algebra/Lie_algebra_interface.jl
@@ -30,15 +30,15 @@ this is internally just a `const` of the corresponding $(_link(:TangentSpace)).
 
 # Constructor
 
-    LieAlgebra(G::LieGroup)
+    LieAlgebra(G::AbstractLieGroup)
 
 Return the Lie Algebra belonging to the [`AbstractLieGroup`](@ref) `G`.
 """
-const LieAlgebra{𝔽,O<:AbstractGroupOperation,G<:LieGroup{𝔽,O}} = ManifoldsBase.Fiber{
+const LieAlgebra{𝔽,O<:AbstractGroupOperation,G<:AbstractLieGroup{𝔽,O}} = ManifoldsBase.Fiber{
     𝔽,ManifoldsBase.TangentSpaceType,G,Identity{O}
 }
 
-function LieAlgebra(G::LieGroup{𝔽,O}) where {𝔽,O<:AbstractGroupOperation}
+function LieAlgebra(G::AbstractLieGroup{𝔽,O}) where {𝔽,O<:AbstractGroupOperation}
     return LieAlgebra{𝔽,O,typeof(G)}(G, Identity(G), ManifoldsBase.TangentSpaceType())
 end
 

--- a/src/Lie_algebra/Lie_algebra_interface.jl
+++ b/src/Lie_algebra/Lie_algebra_interface.jl
@@ -12,8 +12,6 @@ The Lie algebras considered here are those related to a [`AbstractLieGroup`](@re
 namely the tangent space ``T_{$(_math(:e))}$(_math(:G))`` at the [`Identity`](@ref),
 this is internally just a `const` of the corresponding $(_link(:TangentSpace)).
 
-
-
 !!! note "Convention for representing tangent vectors in the Lie algebra"
     A vector field ``$(_tex(:Cal,"X")): $(_math(:G)) → T$(_math(:G))``, ``X(g) ∈ T_g$(_math(:G))``
     is called a left-invariant vector field if it satisfies
@@ -292,7 +290,7 @@ function lie_bracket! end
 lie_bracket!(𝔤::LieAlgebra, Z, X, Y)
 
 function LinearAlgebra.norm(𝔤::LieAlgebra, X)
-    return LinearAlgebra.norm(base_manifold(𝔤), identity_element(base_lie_group(𝔤)), X)
+    return norm(base_manifold(𝔤), identity_element(base_lie_group(𝔤)), X)
 end
 # Avoid an ambiguity
 function LinearAlgebra.norm(𝔤::LA, X::Real) where {LA<:LieAlgebra}

--- a/src/Lie_algebra/Lie_algebra_interface.jl
+++ b/src/Lie_algebra/Lie_algebra_interface.jl
@@ -8,7 +8,7 @@ Represent the Lie algebra ``$(_math(:𝔤))``, that is a ``𝔽`` vector space w
 1. ``[X,X] = 0`` for all ``X ∈ $(_math(:𝔤))``
 2. The Jacobi identity ``[X, [Y,Z]] = [[X,Y],Z] = [Y, [X,Z]]`` holds for all ``X, Y, Z ∈ $(_math(:𝔤))``.
 
-The Lie algebras considered here are those related to a [`LieGroup`](@ref) ``$(_math(:G))``,
+The Lie algebras considered here are those related to a [`AbstractLieGroup`](@ref) ``$(_math(:G))``,
 namely the tangent space ``T_{$(_math(:e))}$(_math(:G))`` at the [`Identity`](@ref),
 this is internally just a `const` of the corresponding $(_link(:TangentSpace)).
 
@@ -32,7 +32,7 @@ this is internally just a `const` of the corresponding $(_link(:TangentSpace)).
 
     LieAlgebra(G::LieGroup)
 
-Return the Lie Algebra belonging to the [`LieGroup`](@ref) `G`.
+Return the Lie Algebra belonging to the [`AbstractLieGroup`](@ref) `G`.
 """
 const LieAlgebra{𝔽,O<:AbstractGroupOperation,G<:LieGroup{𝔽,O}} = ManifoldsBase.Fiber{
     𝔽,ManifoldsBase.TangentSpaceType,G,Identity{O}
@@ -46,7 +46,7 @@ end
     base_manifold(𝔤::LieAlgebra)
 
 Return the [`base_manifold`](@extref `ManifoldsBase.base_manifold`) the
-[`LieGroup`](@ref) of the given [`LieAlgebra`](@ref) is based on.
+[`AbstractLieGroup`](@ref) of the given [`LieAlgebra`](@ref) is based on.
 """
 ManifoldsBase.base_manifold(𝔤::LieAlgebra) = base_manifold(base_lie_group(𝔤))
 
@@ -123,9 +123,9 @@ function get_coordinates_lie!(
 end
 
 _doc_get_vector = """
-    get_vector(G::LieGroup, c, B::AbstractBasis; kwargs...)
+    get_vector(G::AbstractLieGroup, c, B::AbstractBasis; kwargs...)
     get_vector(𝔤::LieAlgebra, c, B::AbstractBasis; kwargs...)
-    get_vector!(G::LieGroup, X::T, c, B::AbstractBasis; kwargs...)
+    get_vector!(G::AbstractLieGroup, X::T, c, B::AbstractBasis; kwargs...)
     get_vector!(𝔤::LieAlgebra, X::T, c, B::AbstractBasis; kwargs...)
 
 Return the vector corresponding to a set of coefficients in an [`AbstractBasis`](@extref `ManifoldsBase.AbstractBasis`)
@@ -261,7 +261,7 @@ end
 Check whether `X` is a valid point on the Lie Algebra `𝔤`.
 This falls back to checking whether `X` is a valid point on the tangent space
 at the [`identity_element`](@ref)`(G)` on the [`base_manifold`](@ref)`(G)`
-on the [`LieGroup`](@ref) of `𝔤`
+on the [`AbstractLieGroup`](@ref) of `𝔤`
 """
 function ManifoldsBase.is_point(𝔤::LieAlgebra, X::T; kwargs...) where {T}
     return ManifoldsBase.is_vector(
@@ -313,7 +313,7 @@ end
 _doc_rand_algebra = """
     rand(::LieGroup; vector_at=nothing, σ=1.0, kwargs...)
     rand(::LieAlgebra; σ=1.0, kwargs...)
-    rand!(::LieGroup, gX; vector_at=nothing, kwargs...)
+    rand!(::AbstractLieGroup, gX; vector_at=nothing, kwargs...)
     rand!(::LieAlgebra, X; σ=1.0, kwargs...)
 
 Compute a random point or tangent vector on a Lie group.
@@ -397,7 +397,7 @@ end
     zero_vector!(𝔤::LieAlgebra, X::T)
 
 Generate a $(_link(:zero_vector)) of type `T` in the [`LieAlgebra`](@ref) ``𝔤`` of
-the [`LieGroup`](@ref) `G`.
+the [`AbstractAbstractAbstractLieGroup`](@ref) `G`.
 By default this calls `zero_vector` on the manifold of `G` at the `identity_element(G,T)`
 
 For the allocating variant the type `T` of the zero vector can be specified.

--- a/src/Lie_algebra/Lie_algebra_interface.jl
+++ b/src/Lie_algebra/Lie_algebra_interface.jl
@@ -397,7 +397,7 @@ end
     zero_vector!(𝔤::LieAlgebra, X::T)
 
 Generate a $(_link(:zero_vector)) of type `T` in the [`LieAlgebra`](@ref) ``𝔤`` of
-the [`AbstractAbstractAbstractLieGroup`](@ref) `G`.
+the [`AbstractLieGroup`](@ref) `G`.
 By default this calls `zero_vector` on the manifold of `G` at the `identity_element(G,T)`
 
 For the allocating variant the type `T` of the zero vector can be specified.

--- a/src/Lie_algebra/Lie_algebra_interface.jl
+++ b/src/Lie_algebra/Lie_algebra_interface.jl
@@ -82,7 +82,7 @@ function ManifoldsBase.get_coordinates(
 end
 # Mimic the levels from ManifoldsBase just without the base point p
 function ManifoldsBase._get_coordinates(𝔤::LieAlgebra, X::T, B::AbstractBasis) where {T}
-    G = 𝔤.manifold
+    G = base_lie_group(𝔤)
     return get_coordinates(base_manifold(G), identity_element(G, T), X, B)
 end
 @doc "$(_doc_get_coordinates)"

--- a/src/group_actions/group_action_interface.jl
+++ b/src/group_actions/group_action_interface.jl
@@ -18,14 +18,14 @@ _note_action_argument_order = """
     AbstractLeftGroupActionType <: AbstractGroupActionType
 
 A type representing a (smooth) group action ``σ: $(_math(:G)) × $(_math(:M)) → $(_math(:M))``
-of a [`LieGroup`](@ref) ``$(_math(:G))`` acting (from the left) on an $(_link(:AbstractManifold)) ``$(_math(:M))``.
+of a [`AbstractLieGroup`](@ref) ``$(_math(:G))`` acting (from the left) on an $(_link(:AbstractManifold)) ``$(_math(:M))``.
 with the following properties
 
 1. ``σ($(_math(:e)), p) = p`` holds for all ``p ∈ $(_math(:M))``
 2. ``σ(g, σ(h, p)) = σ(g$(_math(:∘))h, p)`` holds for all ``g,h ∈ $(_math(:G))``, ``p ∈ $(_math(:M))``
 
 
-where ``$(_math(:∘))`` denotes the group operation of the [`LieGroup`](@ref) ``$(_math(:G))``.
+where ``$(_math(:∘))`` denotes the group operation of the [`AbstractLieGroup`](@ref) ``$(_math(:G))``.
 See also [HilgertNeeb:2012; Definition 9.1.11](@cite).
 
 The type of action can be seen a bit better when writing the action as a family ``σ_g(p)``:
@@ -54,13 +54,13 @@ abstract type AbstractLeftGroupActionType <: AbstractGroupActionType end
     AbstractRightGroupActionType <: AbstractGroupActionType
 
 A type representing a (smooth) group action ``σ: $(_math(:M)) × $(_math(:G)) → $(_math(:M))``
-of a [`LieGroup`](@ref) ``$(_math(:G))`` acting (from the right) on an $(_link(:AbstractManifold)) ``$(_math(:M))``.
+of a [`AbstractLieGroup`](@ref) ``$(_math(:G))`` acting (from the right) on an $(_link(:AbstractManifold)) ``$(_math(:M))``.
 with the following properties
 
 1. ``σ(p, $(_math(:e))) = p`` holds for all ``p ∈ $(_math(:M))``
 2. ``σ(σ(p, g), h) = σ(p, g$(_math(:∘))h)`` holds for all ``g,h ∈ $(_math(:G))``, ``p ∈ $(_math(:M))``
 
-where ``$(_math(:∘))`` denotes the group operation of the [`LieGroup`](@ref) ``$(_math(:G))``.
+where ``$(_math(:∘))`` denotes the group operation of the [`AbstractLieGroup`](@ref) ``$(_math(:G))``.
 See also [HilgertNeeb:2012; Remark 9.1.12](@cite).
 
 The type of action can be seen a bit better when writing the action as a family ``σ_g(p)``:
@@ -88,9 +88,9 @@ abstract type AbstractRightGroupActionType <: AbstractGroupActionType end
 """
     GroupAction{T<:GroupActionType, L<:LieGroup, M<:AbstractManifold}
 
-Specify a group action of [`AbstractGroupActionType`](@ref) `T` of a [`LieGroup`](@ref) `G` acting on `M`.
+Specify a group action of [`AbstractGroupActionType`](@ref) `T` of a [`AbstractLieGroup`](@ref) `G` acting on `M`.
 
-Let ``$(_math(:M))`` be a $(_link(:AbstractManifold)) and ``$(_math(:G))`` be a [`LieGroup`](@ref)
+Let ``$(_math(:M))`` be a $(_link(:AbstractManifold)) and ``$(_math(:G))`` be a [`AbstractLieGroup`](@ref)
 with group operation ``$(_math(:∘))``.
 
 A (smooth) action of the group ``$(_math(:G))`` on the manifold ``$(_math(:M))`` is a map
@@ -114,7 +114,7 @@ with the properties
 See [HilgertNeeb:2012; Section 9.1.3](@cite) for more details.
 
 """
-struct GroupAction{T<:AbstractGroupActionType,L<:LieGroup,M<:ManifoldsBase.AbstractManifold}
+struct GroupAction{T<:AbstractGroupActionType,L<:AbstractLieGroup,M<:ManifoldsBase.AbstractManifold}
     type::T
     group::L
     manifold::M
@@ -151,7 +151,7 @@ function base_lie_group end
 @doc """
     base_lie_group(A::GroupAction)
 
-Return the [`LieGroup`](@ref) of the [`GroupAction`](@ref)
+Return the [`AbstractLieGroup`](@ref) of the [`GroupAction`](@ref)
 specifying the action.
 """
 base_lie_group(A::GroupAction) = A.group
@@ -165,19 +165,19 @@ ManifoldsBase.base_manifold(A::GroupAction) = A.manifold
 
 function default_left_action end
 """
-    default_left_action(G::LieGroup, M::AbstractManifold)
+    default_left_action(G::AbstractLieGroup, M::AbstractManifold)
 
 Return the default left action for a Lie group `G` acting on a manifold `M`.
 """
-default_left_action(N::LieGroup, M::AbstractManifold)
+default_left_action(N::AbstractLieGroup, M::AbstractManifold)
 
 function default_right_action end
 """
-    default_right_action(G::LieGroup, M::AbstractManifold)
+    default_right_action(G::AbstractLieGroup, M::AbstractManifold)
 
 Return the default right action for a Lie group `G` acting on a manifold `M`.
 """
-default_right_action(N::LieGroup, M::AbstractManifold)
+default_right_action(N::AbstractLieGroup, M::AbstractManifold)
 
 _doc_diff_apply = """
     diff_apply(A::GroupAction{T, L, M}, g, p, X)

--- a/src/group_actions/group_action_interface.jl
+++ b/src/group_actions/group_action_interface.jl
@@ -114,7 +114,9 @@ with the properties
 See [HilgertNeeb:2012; Section 9.1.3](@cite) for more details.
 
 """
-struct GroupAction{T<:AbstractGroupActionType,L<:AbstractLieGroup,M<:ManifoldsBase.AbstractManifold}
+struct GroupAction{
+    T<:AbstractGroupActionType,L<:AbstractLieGroup,M<:ManifoldsBase.AbstractManifold
+}
     type::T
     group::L
     manifold::M

--- a/src/group_operations/addition_operation.jl
+++ b/src/group_operations/addition_operation.jl
@@ -112,7 +112,7 @@ _doc_exp_add = """
     exp(G::LieGroup{𝔽,AdditionGroupOperation}, X)
     exp!(G::LieGroup{𝔽,AdditionGroupOperation}, g, X)
 
-Compute the Lie group exponential on a [`LieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
+Compute the Lie group exponential on a [`AbstractLieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
 This can be computed in-place of `g`.
 
 Since `e` is just the zero-element with respect to the corresponding `+`, the formula reads ``g=0+X=X``.
@@ -188,7 +188,7 @@ _doc_log_add = """
     log(G::LieGroup{𝔽,AdditionGroupOperation}, g)
     log!(G::LieGroup{𝔽,AdditionGroupOperation}, X, g)
 
-Compute the Lie group logarithm on a [`LieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
+Compute the Lie group logarithm on a [`AbstractLieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
 This can be computed in-place of `X`.
 
 Since `e` is just the zero-element with respect to the corresponding `+`, the formula reads ``X=g-0=g``.

--- a/src/group_operations/addition_operation.jl
+++ b/src/group_operations/addition_operation.jl
@@ -112,7 +112,7 @@ _doc_exp_add = """
     exp(G::LieGroup{𝔽,AdditionGroupOperation}, X)
     exp!(G::LieGroup{𝔽,AdditionGroupOperation}, g, X)
 
-Compute the Lie group exponential on a [`AbstractLieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
+Compute the Lie group exponential on a [`LieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
 This can be computed in-place of `g`.
 
 Since `e` is just the zero-element with respect to the corresponding `+`, the formula reads ``g=0+X=X``.
@@ -188,7 +188,7 @@ _doc_log_add = """
     log(G::LieGroup{𝔽,AdditionGroupOperation}, g)
     log!(G::LieGroup{𝔽,AdditionGroupOperation}, X, g)
 
-Compute the Lie group logarithm on a [`AbstractLieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
+Compute the Lie group logarithm on a [`LieGroup`](@ref) with an [`AdditionGroupOperation`](@ref).
 This can be computed in-place of `X`.
 
 Since `e` is just the zero-element with respect to the corresponding `+`, the formula reads ``X=g-0=g``.

--- a/src/group_operations/addition_operation.jl
+++ b/src/group_operations/addition_operation.jl
@@ -180,7 +180,9 @@ The computation can be done in-place of `Z`.
 lie_bracket(𝔤::LieAlgebra{𝔽,AdditionGroupOperation}, X, Y) where {𝔽}
 
 @doc "$(_doc_lie_bracket_add)"
-function lie_bracket!(𝔤::LieAlgebra{𝔽,AdditionGroupOperation}, Z, X, Y) where {𝔽}
+function lie_bracket!(
+    𝔤::LieAlgebra{𝔽,O,<:LieGroup{𝔽,O}}, Z, X, Y
+) where {𝔽,O<:AdditionGroupOperation}
     return zero_vector!(𝔤, Z)
 end
 

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -282,7 +282,9 @@ The computation can be done in-place of `Z`.
 lie_bracket(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
 
 @doc "$(_doc_lie_bracket_mult)"
-function lie_bracket!(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, Z, X, Y) where {𝔽}
+function lie_bracket!(
+    ::LieAlgebra{𝔽,O,<:LieGroup{𝔽,O}}, Z, X, Y
+) where {𝔽,O<:MatrixMultiplicationGroupOperation}
     mul!(Z, X, Y)
     mul!(Z, Y, X, -1, true)
     return Z

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -73,10 +73,7 @@ compose(
 
 @doc "$(_doc_compose_mult)"
 compose!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    ::Any,
-    ::Any,
-    ::Any,
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 function _compose!(
@@ -107,11 +104,7 @@ diff_conjugate(
 
 @doc "$(_doc_diff_conjugate_add)"
 function diff_conjugate!(
-    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    Y,
-    g,
-    h,
-    X,
+    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
 ) where {𝔽}
     inv_right_compose!(G, Y, X, g) # Y = Xg^{-1}
     compose!(G, Y, g, Y) # Y = gY
@@ -139,7 +132,9 @@ Then we get ``g^{$(_tex(:transp))}(g^{-1}(gX)g^{-1})`` which simplifies to ``-g^
 """
 
 @doc "$(_doc_diff_inv_mult)"
-diff_inv(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
+diff_inv(
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any
+) where {𝔽}
 
 function diff_inv(
     ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
@@ -151,7 +146,9 @@ function diff_inv(
 end
 
 @doc "$(_doc_diff_inv_mult)"
-function diff_inv!(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p, X) where {𝔽}
+function diff_inv!(
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p, X
+) where {𝔽}
     p_inv = inv(p)
     Z = X * p_inv
     mul!(Y, p', Z)
@@ -169,19 +166,12 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dλ_
 
 @doc "$(_doc_diff_left_compose_mult)"
 diff_left_compose(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    ::Any,
-    ::Any,
-    ::Any,
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 @doc "$(_doc_diff_left_compose_mult)"
 function diff_left_compose!(
-    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    Y,
-    g,
-    h,
-    X,
+    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
 ) where {𝔽}
     return copyto!(LieAlgebra(G), Y, g * X)
 end
@@ -196,19 +186,12 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dρ_
 
 @doc "$(_doc_diff_right_compose_mult)"
 diff_right_compose(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    ::Any,
-    ::Any,
-    ::Any,
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 @doc "$(_doc_diff_right_compose_mult)"
 function diff_right_compose!(
-    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    Y,
-    g,
-    ::Any,
-    X,
+    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, ::Any, X
 ) where {𝔽}
     return copyto!(LieAlgebra(G), Y, X * g)
 end
@@ -224,7 +207,9 @@ This can be computed in-place of `g`.
 """
 
 @doc "$(_doc_exponential_mult)"
-ManifoldsBase.exp(::AbstractLieGroup{𝔽,<:MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
+ManifoldsBase.exp(
+    ::AbstractLieGroup{𝔽,<:MatrixMultiplicationGroupOperation}, ::Any
+) where {𝔽}
 
 @doc "$(_doc_exponential_mult)"
 function ManifoldsBase.exp!(
@@ -250,8 +235,7 @@ identity_element!(
     ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any
 ) where {𝔽}
 function identity_element!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
-    e::AbstractMatrix,
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e::AbstractMatrix
 ) where {𝔽}
     return copyto!(e, LinearAlgebra.I)
 end
@@ -273,9 +257,7 @@ function inv!(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h
     return h
 end
 function inv!(
-    G::AbstractLieGroup{𝔽,O},
-    q,
-    ::Identity{O},
+    G::AbstractLieGroup{𝔽,O}, q, ::Identity{O}
 ) where {𝔽,O<:AbstractMultiplicationGroupOperation}
     return identity_element!(G, q)
 end

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -56,29 +56,25 @@ function Base.:\(
 end
 
 _doc_compose_mult = """
-    compose(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h)
-    compose!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h)
+    compose(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h)
+    compose!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h)
 
 Compute the group operation composition of `g` and `h` with respect to
-an [`AbstractMultiplicationGroupOperation`](@ref) on an [`AbstractLieGroup`](@ref) `G`, which falls back to calling
+an [`AbstractMultiplicationGroupOperation`](@ref) on an [`LieGroup`](@ref) `G`, which falls back to calling
 `g*h`, where `*` is assumed to be overloaded accordingly.
 
 This can be computed in-place of `k`.
 """
 
 @doc "$(_doc_compose_mult)"
-compose(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any
-) where {𝔽}
+compose(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
 
 @doc "$(_doc_compose_mult)"
 compose!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
-function _compose!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h
-) where {𝔽}
+function _compose!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h) where {𝔽}
     # perform the multiplication “safe”, that is, even when providing
     # one of the inputs `g,h`` and as output `k`
     (k === g || k === h) ? copyto!(k, g * h) : mul!(k, g, h)
@@ -90,8 +86,8 @@ Base.inv(e::Identity{<:AbstractMultiplicationGroupOperation}) = e
 LinearAlgebra.det(::Identity{<:AbstractMultiplicationGroupOperation}) = true
 
 _doc_diff_conjugate_add = """
-    diff_conjugate(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
-    diff_conjugate!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
+    diff_conjugate(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
+    diff_conjugate!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
 
 Compute the differential of the conjugate ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1} = ghg^{-1}``,
 which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``D(c_g(h))[X] = gXg^{-1}``.
@@ -99,12 +95,12 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``D(c_
 
 @doc "$(_doc_diff_conjugate_add)"
 diff_conjugate(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 @doc "$(_doc_diff_conjugate_add)"
 function diff_conjugate!(
-    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
+    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
 ) where {𝔽}
     inv_right_compose!(G, Y, X, g) # Y = Xg^{-1}
     compose!(G, Y, g, Y) # Y = gY
@@ -112,11 +108,11 @@ function diff_conjugate!(
 end
 
 _doc_diff_inv_mult = """
-    diff_inv(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, X)
-    diff_inv!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, X)
+    diff_inv(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, X)
+    diff_inv!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, X)
 
 Compute the value of differential ``Dι_{$(_math(:G))}(g)[X]`` of matrix inversion ``ι_{$(_math(:G))}(g) := g^{-1}`` at ``X ∈ 𝔤``
-in the [`LieAlgebra`](@ref) ``𝔤`` of the [`AbstractLieGroup`](@ref) `G`.
+in the [`LieAlgebra`](@ref) ``𝔤`` of the [`LieGroup`](@ref) `G`.
 
 The formula is given by
 
@@ -132,12 +128,10 @@ Then we get ``g^{$(_tex(:transp))}(g^{-1}(gX)g^{-1})`` which simplifies to ``-g^
 """
 
 @doc "$(_doc_diff_inv_mult)"
-diff_inv(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any
-) where {𝔽}
+diff_inv(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
 
 function diff_inv(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
     p::AbstractArray{<:Number,0},
     X::AbstractArray{<:Number,0},
 ) where {𝔽}
@@ -146,9 +140,7 @@ function diff_inv(
 end
 
 @doc "$(_doc_diff_inv_mult)"
-function diff_inv!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p, X
-) where {𝔽}
+function diff_inv!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p, X) where {𝔽}
     p_inv = inv(p)
     Z = X * p_inv
     mul!(Y, p', Z)
@@ -157,8 +149,8 @@ function diff_inv!(
 end
 
 _doc_diff_left_compose_mult = """
-    diff_left_compose(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
-    diff_left_compose!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
+    diff_left_compose(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
+    diff_left_compose!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
 
 Compute the differential of the left group multiplication ``λ_g(h) = g$(_math(:∘))h``,
 which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dλ_g(h)[X] = gX``.
@@ -166,18 +158,18 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dλ_
 
 @doc "$(_doc_diff_left_compose_mult)"
 diff_left_compose(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 @doc "$(_doc_diff_left_compose_mult)"
 function diff_left_compose!(
-    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
+    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
 ) where {𝔽}
     return copyto!(LieAlgebra(G), Y, g * X)
 end
 
 _doc_diff_right_compose_mult = """
-    diff_right_compose(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g, X)
+    diff_right_compose(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g, X)
     diff_right_compose!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, h, g, X)
 
 Compute the differential of the right group multiplication ``ρ_g(h) = h$(_math(:∘))g``,
@@ -186,91 +178,87 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dρ_
 
 @doc "$(_doc_diff_right_compose_mult)"
 diff_right_compose(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 @doc "$(_doc_diff_right_compose_mult)"
 function diff_right_compose!(
-    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, ::Any, X
+    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, ::Any, X
 ) where {𝔽}
     return copyto!(LieAlgebra(G), Y, X * g)
 end
 
 _doc_exponential_mult = """
-    exp(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, X)
-    exp!(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X)
+    exp(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X)
+    exp!(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X)
 
-Compute the Lie group exponential on a [`AbstractLieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
+Compute the Lie group exponential on a [`LieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
 which simplifies to the [matrix exponential](https://en.wikipedia.org/wiki/Matrix_exponential).
 
 This can be computed in-place of `g`.
 """
 
 @doc "$(_doc_exponential_mult)"
-ManifoldsBase.exp(
-    ::AbstractLieGroup{𝔽,<:MatrixMultiplicationGroupOperation}, ::Any
-) where {𝔽}
+ManifoldsBase.exp(::LieGroup{𝔽,<:MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
 
 @doc "$(_doc_exponential_mult)"
 function ManifoldsBase.exp!(
-    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X
+    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X
 ) where {𝔽}
     copyto!(g, exp(X))
     return g
 end
 
 _doc_identity_element_mult = """
-    identity_element(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation})
-    identity_element!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e)
+    identity_element(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation})
+    identity_element!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e)
 
 Return the a point representation of the [`Identity`](@ref),
 which for an [`AbstractMultiplicationGroupOperation`](@ref) is the one-element or identity array.
 """
 
 @doc "$(_doc_identity_element_mult)"
-identity_element(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}) where {𝔽}
+identity_element(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}) where {𝔽}
 
 @doc "$(_doc_identity_element_mult)"
-identity_element!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any
-) where {𝔽}
+identity_element!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any) where {𝔽}
 function identity_element!(
-    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e::AbstractMatrix
+    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e::AbstractMatrix
 ) where {𝔽}
     return copyto!(e, LinearAlgebra.I)
 end
 
 _doc_inv_mult = """
-    inv(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperationroupOperation}, g)
-    inv!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g)
+    inv(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperationroupOperation}, g)
+    inv!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g)
 
 Compute the inverse group element ``g^{-1}``, which for an [`AbstractMultiplicationGroupOperation`](@ref)
 simplifies to the multiplicative inverse ``g^{-1}``. This can be done in-place of `h`.
 """
 
 @doc "$(_doc_inv_mult)"
-Base.inv(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any) where {𝔽}
+Base.inv(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any) where {𝔽}
 
 @doc "$(_doc_inv_mult)"
-function inv!(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g) where {𝔽}
+function inv!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g) where {𝔽}
     copyto!(h, inv(g))
     return h
 end
 function inv!(
-    G::AbstractLieGroup{𝔽,O}, q, ::Identity{O}
+    G::LieGroup{𝔽,O}, q, ::Identity{O}
 ) where {𝔽,O<:AbstractMultiplicationGroupOperation}
     return identity_element!(G, q)
 end
 
 # Compute g^{-1}h more efficient than inverting g
 function inv_left_compose!(
-    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
+    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
 ) where {𝔽}
     return copyto!(k, g \ h)
 end
 # Compute g∘h^{-1} more efficient than inverting h
 function inv_right_compose!(
-    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
+    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
 ) where {𝔽}
     return copyto!(k, g / h)
 end
@@ -301,46 +289,32 @@ function lie_bracket!(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, Z, 
 end
 
 _doc_log_mult = """
-    log(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, g)
-    log!(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g)
+    log(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, g)
+    log!(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g)
 
-Compute the Lie group logarithm on a [`AbstractLieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
+Compute the Lie group logarithm on a [`LieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
 which simplifies to the [matrix logarithm](https://en.wikipedia.org/wiki/Logarithm_of_a_matrix).
 
 This can be computed in-place of `X`.
 """
 
 @doc "$(_doc_log_mult)"
-ManifoldsBase.log(::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
-
-function ManifoldsBase.log(
-    G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation},
-    ::Identity{MatrixMultiplicationGroupOperation},
-) where {𝔽}
-    return zero_vector(LieAlgebra(G))
-end
-function ManifoldsBase.log(
-    G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation},
-    ::Identity{MatrixMultiplicationGroupOperation},
-    T::Type,
-) where {𝔽}
-    return zero_vector(LieAlgebra(G), T)
-end
+ManifoldsBase.log(::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
 
 @doc "$(_doc_log_mult)"
 function ManifoldsBase.log!(
-    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g
+    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g
 ) where {𝔽}
     copyto!(X, log(g))
     return X
 end
-
 function ManifoldsBase.log!(
-    G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation},
+    G::LieGroup{𝔽,MatrixMultiplicationGroupOperation},
     X,
     ::Identity{MatrixMultiplicationGroupOperation},
 ) where {𝔽}
-    return zero_vector!(LieAlgebra(G), X)
+    zero_vector!(LieAlgebra(G), X)
+    return X
 end
 
 LinearAlgebra.mul!(q, ::Identity{<:AbstractMultiplicationGroupOperation}, p) = copyto!(q, p)

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -56,25 +56,32 @@ function Base.:\(
 end
 
 _doc_compose_mult = """
-    compose(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h)
-    compose!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h)
+    compose(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h)
+    compose!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h)
 
 Compute the group operation composition of `g` and `h` with respect to
-an [`AbstractMultiplicationGroupOperation`](@ref) on `G`, which falls back to calling
+an [`AbstractMultiplicationGroupOperation`](@ref) on an [`AbstractLieGroup`](@ref) `G`, which falls back to calling
 `g*h`, where `*` is assumed to be overloaded accordingly.
 
 This can be computed in-place of `k`.
 """
 
 @doc "$(_doc_compose_mult)"
-compose(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
+compose(
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any
+) where {𝔽}
 
 @doc "$(_doc_compose_mult)"
 compose!(
-    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    ::Any,
+    ::Any,
+    ::Any,
 ) where {𝔽}
 
-function _compose!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h) where {𝔽}
+function _compose!(
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, k, g, h
+) where {𝔽}
     # perform the multiplication “safe”, that is, even when providing
     # one of the inputs `g,h`` and as output `k`
     (k === g || k === h) ? copyto!(k, g * h) : mul!(k, g, h)
@@ -86,8 +93,8 @@ Base.inv(e::Identity{<:AbstractMultiplicationGroupOperation}) = e
 LinearAlgebra.det(::Identity{<:AbstractMultiplicationGroupOperation}) = true
 
 _doc_diff_conjugate_add = """
-    diff_conjugate(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
-    diff_conjugate!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
+    diff_conjugate(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
+    diff_conjugate!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
 
 Compute the differential of the conjugate ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1} = ghg^{-1}``,
 which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``D(c_g(h))[X] = gXg^{-1}``.
@@ -95,12 +102,16 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``D(c_
 
 @doc "$(_doc_diff_conjugate_add)"
 diff_conjugate(
-    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
 ) where {𝔽}
 
 @doc "$(_doc_diff_conjugate_add)"
 function diff_conjugate!(
-    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
+    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    Y,
+    g,
+    h,
+    X,
 ) where {𝔽}
     inv_right_compose!(G, Y, X, g) # Y = Xg^{-1}
     compose!(G, Y, g, Y) # Y = gY
@@ -108,11 +119,11 @@ function diff_conjugate!(
 end
 
 _doc_diff_inv_mult = """
-    diff_inv(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, X)
-    diff_inv!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, X)
+    diff_inv(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, X)
+    diff_inv!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, X)
 
 Compute the value of differential ``Dι_{$(_math(:G))}(g)[X]`` of matrix inversion ``ι_{$(_math(:G))}(g) := g^{-1}`` at ``X ∈ 𝔤``
-in the [`LieAlgebra`](@ref) ``𝔤`` of the [`LieGroup`](@ref) `G`.
+in the [`LieAlgebra`](@ref) ``𝔤`` of the [`AbstractLieGroup`](@ref) `G`.
 
 The formula is given by
 
@@ -128,10 +139,10 @@ Then we get ``g^{$(_tex(:transp))}(g^{-1}(gX)g^{-1})`` which simplifies to ``-g^
 """
 
 @doc "$(_doc_diff_inv_mult)"
-diff_inv(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
+diff_inv(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any) where {𝔽}
 
 function diff_inv(
-    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
     p::AbstractArray{<:Number,0},
     X::AbstractArray{<:Number,0},
 ) where {𝔽}
@@ -140,7 +151,7 @@ function diff_inv(
 end
 
 @doc "$(_doc_diff_inv_mult)"
-function diff_inv!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p, X) where {𝔽}
+function diff_inv!(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p, X) where {𝔽}
     p_inv = inv(p)
     Z = X * p_inv
     mul!(Y, p', Z)
@@ -149,8 +160,8 @@ function diff_inv!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, p
 end
 
 _doc_diff_left_compose_mult = """
-    diff_left_compose(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
-    diff_left_compose!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
+    diff_left_compose(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, g, h, X)
+    diff_left_compose!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X)
 
 Compute the differential of the left group multiplication ``λ_g(h) = g$(_math(:∘))h``,
 which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dλ_g(h)[X] = gX``.
@@ -158,18 +169,25 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dλ_
 
 @doc "$(_doc_diff_left_compose_mult)"
 diff_left_compose(
-    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    ::Any,
+    ::Any,
+    ::Any,
 ) where {𝔽}
 
 @doc "$(_doc_diff_left_compose_mult)"
 function diff_left_compose!(
-    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, h, X
+    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    Y,
+    g,
+    h,
+    X,
 ) where {𝔽}
     return copyto!(LieAlgebra(G), Y, g * X)
 end
 
 _doc_diff_right_compose_mult = """
-    diff_right_compose(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g, X)
+    diff_right_compose(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g, X)
     diff_right_compose!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, h, g, X)
 
 Compute the differential of the right group multiplication ``ρ_g(h) = h$(_math(:∘))g``,
@@ -178,94 +196,106 @@ which simplifies for an [`AbstractMultiplicationGroupOperation`](@ref) to ``Dρ_
 
 @doc "$(_doc_diff_right_compose_mult)"
 diff_right_compose(
-    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any, ::Any, ::Any
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    ::Any,
+    ::Any,
+    ::Any,
 ) where {𝔽}
 
 @doc "$(_doc_diff_right_compose_mult)"
 function diff_right_compose!(
-    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, Y, g, ::Any, X
+    G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    Y,
+    g,
+    ::Any,
+    X,
 ) where {𝔽}
     return copyto!(LieAlgebra(G), Y, X * g)
 end
 
 _doc_exponential_mult = """
-    exp(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X)
-    exp!(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X)
+    exp(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, X)
+    exp!(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X)
 
-Compute the Lie group exponential on a [`LieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
+Compute the Lie group exponential on a [`AbstractLieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
 which simplifies to the [matrix exponential](https://en.wikipedia.org/wiki/Matrix_exponential).
 
 This can be computed in-place of `g`.
 """
 
 @doc "$(_doc_exponential_mult)"
-ManifoldsBase.exp(::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
+ManifoldsBase.exp(::AbstractLieGroup{𝔽,<:MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
 
 @doc "$(_doc_exponential_mult)"
 function ManifoldsBase.exp!(
-    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X
+    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, g, X
 ) where {𝔽}
     copyto!(g, exp(X))
     return g
 end
 
 _doc_identity_element_mult = """
-    identity_element(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation})
-    identity_element!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e)
+    identity_element(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation})
+    identity_element!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e)
 
 Return the a point representation of the [`Identity`](@ref),
 which for an [`AbstractMultiplicationGroupOperation`](@ref) is the one-element or identity array.
 """
 
 @doc "$(_doc_identity_element_mult)"
-identity_element(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}) where {𝔽}
+identity_element(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}) where {𝔽}
 
 @doc "$(_doc_identity_element_mult)"
-identity_element!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any) where {𝔽}
+identity_element!(
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any
+) where {𝔽}
 function identity_element!(
-    ::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, e::AbstractMatrix
+    ::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation},
+    e::AbstractMatrix,
 ) where {𝔽}
     return copyto!(e, LinearAlgebra.I)
 end
 
 _doc_inv_mult = """
-    inv(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperationroupOperation}, g)
-    inv!(G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g)
+    inv(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperationroupOperation}, g)
+    inv!(G::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g)
 
 Compute the inverse group element ``g^{-1}``, which for an [`AbstractMultiplicationGroupOperation`](@ref)
 simplifies to the multiplicative inverse ``g^{-1}``. This can be done in-place of `h`.
 """
 
 @doc "$(_doc_inv_mult)"
-Base.inv(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any) where {𝔽}
+Base.inv(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Any) where {𝔽}
 
 @doc "$(_doc_inv_mult)"
-function inv!(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g) where {𝔽}
+function inv!(::AbstractLieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, h, g) where {𝔽}
     copyto!(h, inv(g))
     return h
 end
 function inv!(
-    G::LieGroup{𝔽,O}, q, ::Identity{O}
+    G::AbstractLieGroup{𝔽,O},
+    q,
+    ::Identity{O},
 ) where {𝔽,O<:AbstractMultiplicationGroupOperation}
     return identity_element!(G, q)
 end
 
 # Compute g^{-1}h more efficient than inverting g
 function inv_left_compose!(
-    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
+    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
 ) where {𝔽}
     return copyto!(k, g \ h)
 end
 # Compute g∘h^{-1} more efficient than inverting h
 function inv_right_compose!(
-    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
+    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, k, g, h
 ) where {𝔽}
     return copyto!(k, g / h)
 end
 
 _doc_lie_bracket_mult = """
-    lie_bracket(::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, Y)
-    lie_bracket!(::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, Z, X, Y)
+    lie_bracket(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, X, Y)
+    lie_bracket!(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, Z, X, Y)
 
 Compute the Lie bracket ``[⋅,⋅]: $(_math(:𝔤))×$(_math(:𝔤)) → $(_math(:𝔤))``,
 which for the for the [`MatrixMultiplicationGroupOperation`](@ref) yields the
@@ -289,26 +319,26 @@ function lie_bracket!(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, Z, 
 end
 
 _doc_log_mult = """
-    log(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, g)
-    log!(G::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g)
+    log(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, g)
+    log!(G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g)
 
-Compute the Lie group logarithm on a [`LieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
+Compute the Lie group logarithm on a [`AbstractLieGroup`](@ref) with a [`MatrixMultiplicationGroupOperation`](@ref),
 which simplifies to the [matrix logarithm](https://en.wikipedia.org/wiki/Logarithm_of_a_matrix).
 
 This can be computed in-place of `X`.
 """
 
 @doc "$(_doc_log_mult)"
-ManifoldsBase.log(::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
+ManifoldsBase.log(::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, ::Any) where {𝔽}
 
 function ManifoldsBase.log(
-    G::LieGroup{𝔽,MatrixMultiplicationGroupOperation},
+    G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation},
     ::Identity{MatrixMultiplicationGroupOperation},
 ) where {𝔽}
     return zero_vector(LieAlgebra(G))
 end
 function ManifoldsBase.log(
-    G::LieGroup{𝔽,MatrixMultiplicationGroupOperation},
+    G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation},
     ::Identity{MatrixMultiplicationGroupOperation},
     T::Type,
 ) where {𝔽}
@@ -317,14 +347,14 @@ end
 
 @doc "$(_doc_log_mult)"
 function ManifoldsBase.log!(
-    ::LieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g
+    ::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation}, X, g
 ) where {𝔽}
     copyto!(X, log(g))
     return X
 end
 
 function ManifoldsBase.log!(
-    G::LieGroup{𝔽,MatrixMultiplicationGroupOperation},
+    G::AbstractLieGroup{𝔽,MatrixMultiplicationGroupOperation},
     X,
     ::Identity{MatrixMultiplicationGroupOperation},
 ) where {𝔽}

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -90,7 +90,7 @@ const SpecialEuclideanGroupOperation = Union{
 """
     SpecialEuclideanMatrixPoint <: AbstractLieGroupPoint
 
-represent a point on some [`LieGroup`](@ref) by an [affine matrix](https://en.wikipedia.org/wiki/Affine_group#Matrix_representation).
+represent a point on some [`AbstractLieGroup`](@ref) by an [affine matrix](https://en.wikipedia.org/wiki/Affine_group#Matrix_representation).
 
 ```math
 $(_tex(:pmatrix, "M & v", "$(_tex(:vec, "0"))_n^{$(_tex(:transp))} & 1")) ∈ ℝ^{(n+1)×(n+1)},
@@ -105,7 +105,7 @@ end
 """
     SpecialEuclideanMatrixTangentVector <: AbstractLieAlgebraTangentVector
 
-represent a tangent vector on some [`LieGroup`](@ref) by a matrix of the form
+represent a tangent vector on some [`AbstractLieGroup`](@ref) by a matrix of the form
 
 ```math
 $(_tex(:pmatrix, "M & v", "$(_tex(:vec, "0"))_n^{$(_tex(:transp))} & 0")) ∈ ℝ^{(n+1)×(n+1)},

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -348,6 +348,31 @@ function ManifoldsBase.exp!(G::ValidationLieGroup, h, g, X; kwargs...)
     return g
 end
 
+function hat(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, c; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    X = hat(LieAlgebra(G), c)
+    is_point(𝔤, X; widthin=hat, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
+end
+function hat(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, c, T::Type; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    X = hat(LieAlgebra(G), c, T)
+    is_point(𝔤, X; widthin=hat, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
+end
+function hat!(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X, c; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    hat!(LieAlgebra(G), internal_value(X), c)
+    is_point(𝔤, X; widthin=hat, context=(:Output,), kwargs...)
+    return X
+end
+
 function identity_element(G::ValidationLieGroup; kwargs...)
     g = identity_element(G.lie_group)
     is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
@@ -469,6 +494,16 @@ function ManifoldsBase.is_point(
     !_vLc(vG, within, (:Vector, context...)) && return true
     return is_point(LieAlgebra(vG.lie_group), internal_value(X); error=error, kwargs...)
 end
+function ManifoldsBase.is_vector(
+    G::ValidationLieGroup{𝔽,O}, e::Identity{O}, X; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    return ManifoldsBase.is_vector(G.lie_group, e, internal_value(X); kwargs...)
+end
+function ManifoldsBase.is_vector(G::ValidationLieGroup, g, X; kwargs...)
+    return ManifoldsBase.is_vector(
+        G.lie_group, internal_value(g), internal_value(X); kwargs...
+    )
+end
 
 function ManifoldsBase.isapprox(G::ValidationLieGroup, g, h; kwargs...)
     is_point(G, g; within=isapprox, context=(:Input,), kwargs...)
@@ -576,9 +611,11 @@ function ManifoldsBase.log!(G::ValidationLieGroup, X, g, h; kwargs...)
     return X
 end
 
-function LinearAlgebra.norm(𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X; kwargs...) where {𝔽, O<:AbstractGroupOperation}
+function LinearAlgebra.norm(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lie_group
-    is_point(𝔤, X; within=rand, context=(:Input,), kwargs...)
+    is_point(𝔤, X; within=norm, context=(:Input,), kwargs...)
     return norm(LieAlgebra(G), internal_value(X))
 end
 
@@ -611,6 +648,22 @@ function Base.show(io::IO, G::ValidationLieGroup)
     return print(io, s)
 end
 
+function vee(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    is_point(𝔤, X; widthin=vee, context=(:Input,), kwargs...)
+    G = base_lie_group(𝔤).lie_group
+    return vee(LieAlgebra(G), internal_value(X))
+end
+function vee!(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, c, X; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    is_point(𝔤, X; widthin=vee, context=(:Input,), kwargs...)
+    G = base_lie_group(𝔤).lie_group
+    vee!(LieAlgebra(G), internal_value(c), internal_value(X))
+    return X
+end
+
 function ManifoldsBase.zero_vector(
     𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, T::Type
 ) where {𝔽,O<:AbstractGroupOperation}
@@ -635,5 +688,5 @@ function ManifoldsBase.zero_vector!(
 ) where {𝔽,O<:AbstractGroupOperation,T}
     G = base_lie_group(𝔤).lie_group
     T2 = typeof(internal_value(X))
-    return ValidationLieAlgebraTangentVector(zero_vector(G, T))
+    return ValidationLieAlgebraTangentVector(zero_vector(G, T2))
 end

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -1,0 +1,31 @@
+"""
+    ValidationLieGroup{L<:AbstractLieGroup} <: AbstractLieGroup
+
+A Lie group to add tests to input parameters and ouptut values of functions defined
+for [`LieGroups`](@ref).
+
+
+# Fields
+
+* `lie_group::L` the [`AbstractLieGroup`](@ref) to be decorated
+* ``
+
+# Constructor
+    ValidationLieGroup(L::AbstractLieGroup; )
+
+Generate the Validation Lie Group for the given [`AbstractLieGroup`](@ref)  `L`
+
+    ValidationLieGroup(M::AbstractManifold, op::AbstractGroupOperation; kwargs...)
+
+Generate the Validation Lie Group for the given [`AbstractLieGroup`](@ref)  `L` based on
+a the [`ValidationManifold`](@extref) of `M` and a group operation `op`, that is, also on the
+manifold operations can be tested. suitable keywords are passed down.
+
+# Keyword arguments
+
+For the second constructor, all further keywords are passed to the [`ValidationManifold`](@ref) as well.
+"""
+struct ValidationLieGroup{𝔽, L<:LieGroup{𝔽}}
+    lie_group::L
+    mode::S
+end

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -1,7 +1,7 @@
 """
     ValidationLieGroup{L<:AbstractLieGroup} <: AbstractLieGroup
 
-A Lie group to add tests to input parameters and ouptut values of functions defined
+A Lie group to add tests to input parameters and output values of functions defined
 for [`LieGroups`](@ref).
 
 
@@ -82,6 +82,11 @@ ManifoldsBase.@manifold_vector_forwards ValidationLieAlgebraTangentVector value
 @default_lie_group_fallbacks ValidationLieGroup AbstractGroupOperation ManifoldsBase.ValidationMPoint ValidationLieAlgebraTangentVector value value
 
 Identity(VG::ValidationLieGroup) = Identity(VG.lie_group)
+
+# similar to `internal_value` but just for Validation  types
+unwrap_validation(v) = v
+unwrap_validation(vTV::ValidationLieAlgebraTangentVector) = vTV.value
+unwrap_validation(vP::ValidationMPoint) = vP.value
 
 #
 #
@@ -173,14 +178,14 @@ end
 function Base.adjoint(G::ValidationLieGroup, g, X; kwargs...)
     is_point(G, g; widthin=adjoint, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=adjoint, context=(:Input,), kwargs...)
-    Y = adjoint(G.lie_group, internal_value(g), internal_value(X))
+    Y = adjoint(G.lie_group, unwrap_validation(g), unwrap_validation(X))
     is_point(LieAlgebra(G), Y; widthin=adjoint, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
 end
 function adjoint!(G::ValidationLieGroup, Y, g, X; kwargs...)
     is_point(G, g; widthin=adjoint, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=adjoint, context=(:Input,), kwargs...)
-    adjoint!(G.lie_group, internal_value(Y), internal_value(g), internal_value(X))
+    adjoint!(G.lie_group, unwrap_validation(Y), unwrap_validation(g), unwrap_validation(X))
     is_point(LieAlgebra(G), Y; widthin=adjoint, context=(:Output,), kwargs...)
     return Y
 end
@@ -190,14 +195,14 @@ Manifolds.base_manifold(G::ValidationLieGroup) = base_manifold(G.lie_group)
 function _compose(G::ValidationLieGroup, g, h; kwargs...)
     is_point(G, g; widthin=compose, context=(:Input,), kwargs...)
     is_point(G, h; widthin=compose, context=(:Input,), kwargs...)
-    k = compose(G.lie_group, internal_value(g), internal_value(h))
+    k = compose(G.lie_group, unwrap_validation(g), unwrap_validation(h))
     is_point(G, k; widthin=compose, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function _compose!(G::ValidationLieGroup, k, g, h; kwargs...)
     is_point(G, g; widthin=compose, context=(:Input,), kwargs...)
     is_point(G, h; widthin=compose, context=(:Input,), kwargs...)
-    compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    compose!(G.lie_group, unwrap_validation(k), unwrap_validation(g), unwrap_validation(h))
     is_point(G, k; widthin=compose, context=(:Output,), kwargs...)
     return k
 end
@@ -205,32 +210,34 @@ end
 function conjugate(G::ValidationLieGroup, g, h; kwargs...)
     is_point(G, g; widthin=conjugate, context=(:Input,), kwargs...)
     is_point(G, h; widthin=conjugate, context=(:Input,), kwargs...)
-    k = conjugate(G.lie_group, internal_value(g), internal_value(h))
+    k = conjugate(G.lie_group, unwrap_validation(g), unwrap_validation(h))
     is_point(G, k; widthin=conjugate, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function conjugate!(G::ValidationLieGroup, k, g, h; kwargs...)
     is_point(G, g; widthin=conjugate, context=(:Input,), kwargs...)
     is_point(G, h; widthin=conjugate, context=(:Input,), kwargs...)
-    conjugate!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    conjugate!(
+        G.lie_group, unwrap_validation(k), unwrap_validation(g), unwrap_validation(h)
+    )
     is_point(G, k; widthin=conjugate, context=(:Output,), kwargs...)
     return k
 end
 
 function Base.copyto!(G::ValidationLieGroup, h, g)
-    copyto!(G.lie_group, internal_value(h), internal_value(g))
+    copyto!(G.lie_group, unwrap_validation(h), unwrap_validation(g))
     return h
 end
 function Base.copyto!(
     G::ValidationLieGroup{𝔽,O}, e::Identity{O}, g
 ) where {𝔽,O<:AbstractGroupOperation}
-    copyto!(G.lie_group, e, internal_value(g))
+    copyto!(G.lie_group, e, unwrap_validation(g))
     return e
 end
 function Base.copyto!(
     G::ValidationLieGroup{𝔽,O}, h, e::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation}
-    copyto!(G.lie_group, internal_value(h), e)
+    copyto!(G.lie_group, unwrap_validation(h), e)
     return h
 end
 function Base.copyto!(
@@ -243,7 +250,9 @@ function diff_conjugate(G::ValidationLieGroup, g, h, X; kwargs...)
     is_point(G, g; widthin=diff_conjugate, context=(:Input,), kwargs...)
     is_point(G, h; widthin=diff_conjugate, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_conjugate, context=(:Input,), kwargs...)
-    Y = diff_conjugate(G.lie_group, internal_value(g), internal_value(h), internal_value(X))
+    Y = diff_conjugate(
+        G.lie_group, unwrap_validation(g), unwrap_validation(h), unwrap_validation(X)
+    )
     is_point(LieAlgebra(G), Y; widthin=diff_conjugate, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
 end
@@ -253,10 +262,10 @@ function diff_conjugate!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_conjugate, context=(:Input,), kwargs...)
     diff_conjugate!(
         G.lie_group,
-        internal_value(Y),
-        internal_value(g),
-        internal_value(h),
-        internal_value(X),
+        unwrap_validation(Y),
+        unwrap_validation(g),
+        unwrap_validation(h),
+        unwrap_validation(X),
     )
     is_point(LieAlgebra(G), Y; widthin=diff_conjugate, context=(:Output,), kwargs...)
     return Y
@@ -265,7 +274,7 @@ end
 function diff_inv!(G::ValidationLieGroup, Y, g, X; kwargs...)
     is_point(G, g; widthin=diff_inv, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_inv, context=(:Input,), kwargs...)
-    diff_inv!(G.lie_group, internal_value(Y), internal_value(g), internal_value(X))
+    diff_inv!(G.lie_group, unwrap_validation(Y), unwrap_validation(g), unwrap_validation(X))
     is_point(LieAlgebra(G), Y; widthin=diff_inv, context=(:Output,), kwargs...)
     return Y
 end
@@ -275,7 +284,7 @@ function diff_left_compose(G::ValidationLieGroup, g, h, X; kwargs...)
     is_point(G, h; widthin=diff_left_compose, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_left_compose, context=(:Input,), kwargs...)
     Y = diff_left_compose(
-        G.lie_group, internal_value(g), internal_value(h), internal_value(X)
+        G.lie_group, unwrap_validation(g), unwrap_validation(h), unwrap_validation(X)
     )
     is_point(LieAlgebra(G), Y; widthin=diff_left_compose, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
@@ -286,10 +295,10 @@ function diff_left_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_left_compose, context=(:Input,), kwargs...)
     diff_left_compose!(
         G.lie_group,
-        internal_value(Y),
-        internal_value(g),
-        internal_value(h),
-        internal_value(X),
+        unwrap_validation(Y),
+        unwrap_validation(g),
+        unwrap_validation(h),
+        unwrap_validation(X),
     )
     is_point(LieAlgebra(G), Y; widthin=diff_left_compose, context=(:Output,), kwargs...)
     return Y
@@ -300,7 +309,7 @@ function diff_right_compose(G::ValidationLieGroup, g, h, X; kwargs...)
     is_point(G, h; widthin=diff_right_compose, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_right_compose, context=(:Input,), kwargs...)
     Y = diff_right_compose(
-        G.lie_group, internal_value(g), internal_value(h), internal_value(X)
+        G.lie_group, unwrap_validation(g), unwrap_validation(h), unwrap_validation(X)
     )
     is_point(LieAlgebra(G), Y; widthin=diff_right_compose, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
@@ -311,10 +320,10 @@ function diff_right_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
     is_point(LieAlgebra(G), X; widthin=diff_right_compose, context=(:Input,), kwargs...)
     diff_right_compose!(
         G.lie_group,
-        internal_value(Y),
-        internal_value(g),
-        internal_value(h),
-        internal_value(X),
+        unwrap_validation(Y),
+        unwrap_validation(g),
+        unwrap_validation(h),
+        unwrap_validation(X),
     )
     is_point(LieAlgebra(G), Y; widthin=diff_right_compose, context=(:Output,), kwargs...)
     return Y
@@ -322,13 +331,13 @@ end
 
 function Base.exp(G::ValidationLieGroup, X; kwargs...)
     is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
-    g = exp(G.lie_group, internal_value(X))
+    g = exp(G.lie_group, unwrap_validation(X))
     is_point(G, g; widthin=exp, context=(:Output,), kwargs...)
     return ValidationMPoint(g)
 end
 function ManifoldsBase.exp!(G::ValidationLieGroup, g, X; kwargs...)
     is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
-    exp!(G.lie_group, internal_value(g), internal_value(X))
+    exp!(G.lie_group, unwrap_validation(g), unwrap_validation(X))
     is_point(G, g; widthin=exp, context=(:Output,), kwargs...)
     return g
 end
@@ -336,14 +345,14 @@ end
 function Base.exp(G::ValidationLieGroup, g, X; kwargs...)
     is_point(G, g; widthin=exp, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
-    h = exp(G.lie_group, internal_value(g), internal_value(X))
+    h = exp(G.lie_group, unwrap_validation(g), unwrap_validation(X))
     is_point(G, h; widthin=exp, context=(:Output,), kwargs...)
     return ValidationMPoint(h)
 end
 function ManifoldsBase.exp!(G::ValidationLieGroup, h, g, X; kwargs...)
     is_point(G, g; widthin=exp, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
-    exp!(G.lie_group, internal_value(h), internal_value(g), internal_value(X))
+    exp!(G.lie_group, unwrap_validation(h), unwrap_validation(g), unwrap_validation(X))
     is_point(G, h; widthin=exp, context=(:Output,), kwargs...)
     return g
 end
@@ -368,7 +377,7 @@ function hat!(
     𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X, c; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lie_group
-    hat!(LieAlgebra(G), internal_value(X), c)
+    hat!(LieAlgebra(G), unwrap_validation(X), c)
     is_point(𝔤, X; widthin=hat, context=(:Output,), kwargs...)
     return X
 end
@@ -380,7 +389,7 @@ function identity_element(G::ValidationLieGroup; kwargs...)
 end
 
 function identity_element!(G::ValidationLieGroup, g; kwargs...)
-    identity_element!(G.lie_group, internal_value(g))
+    identity_element!(G.lie_group, unwrap_validation(g))
     is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
     return g
 end
@@ -392,7 +401,7 @@ end
 
 function Base.inv(G::ValidationLieGroup, g; kwargs...)
     is_point(G, g; widthin=inv, context=(:Input,), kwargs...)
-    h = inv(G.lie_group, internal_value(g))
+    h = inv(G.lie_group, unwrap_validation(g))
     is_point(G, h; widthin=inv, context=(:Output,), kwargs...)
     return ValidationMPoint(h)
 end
@@ -400,11 +409,11 @@ function Base.inv(
     G::LieGroups.ValidationLieGroup{𝔽,O}, e::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     is_identity(G.lie_group, e; kwargs...)
-    return ValidationMPoint(inv(G.lie_group, e))
+    return inv(G.lie_group, e)
 end
 function inv!(G::ValidationLieGroup, h, g; kwargs...)
     is_point(G, g; widthin=inv, context=(:Input,), kwargs...)
-    inv!(G.lie_group, internal_value(h), internal_value(g))
+    inv!(G.lie_group, unwrap_validation(h), unwrap_validation(g))
     is_point(G, h; widthin=inv, context=(:Output,), kwargs...)
     return h
 end
@@ -412,7 +421,7 @@ function inv!(
     G::ValidationLieGroup{𝔽,O}, h, e::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     is_identity(G.lie_group, e; kwargs...)
-    inv!(G.lie_group, internal_value(h), e)
+    inv!(G.lie_group, unwrap_validation(h), e)
     is_point(G, h; widthin=inv, context=(:Output,), kwargs...)
     return h
 end
@@ -420,14 +429,16 @@ end
 function inv_left_compose(G::ValidationLieGroup, g, h; kwargs...)
     is_point(G, g; widthin=inv_left_compose, context=(:Input,), kwargs...)
     is_point(G, h; widthin=inv_left_compose, context=(:Input,), kwargs...)
-    k = inv_left_compose(G.lie_group, internal_value(g), internal_value(h))
+    k = inv_left_compose(G.lie_group, unwrap_validation(g), unwrap_validation(h))
     is_point(G, k; widthin=inv_left_compose, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function inv_left_compose!(G::ValidationLieGroup, k, g, h; kwargs...)
     is_point(G, g; widthin=inv_left_compose, context=(:Input,), kwargs...)
     is_point(G, h; widthin=inv_left_compose, context=(:Input,), kwargs...)
-    inv_left_compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    inv_left_compose!(
+        G.lie_group, unwrap_validation(k), unwrap_validation(g), unwrap_validation(h)
+    )
     is_point(G, k; widthin=inv_left_compose, context=(:Output,), kwargs...)
     return k
 end
@@ -435,19 +446,21 @@ end
 function inv_right_compose(G::ValidationLieGroup, g, h; kwargs...)
     is_point(G, g; widthin=inv_right_compose, context=(:Input,), kwargs...)
     is_point(G, h; widthin=inv_right_compose, context=(:Input,), kwargs...)
-    k = inv_right_compose(G.lie_group, internal_value(g), internal_value(h))
+    k = inv_right_compose(G.lie_group, unwrap_validation(g), unwrap_validation(h))
     is_point(G, k; widthin=inv_right_compose, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function inv_right_compose!(G::ValidationLieGroup, k, g, h; kwargs...)
     is_point(G, g; widthin=inv_right_compose, context=(:Input,), kwargs...)
     is_point(G, h; widthin=inv_right_compose, context=(:Input,), kwargs...)
-    inv_right_compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    inv_right_compose!(
+        G.lie_group, unwrap_validation(k), unwrap_validation(g), unwrap_validation(h)
+    )
     is_point(G, k; widthin=inv_right_compose, context=(:Output,), kwargs...)
     return k
 end
 
-is_identity(G::ValidationLieGroup, g) = is_identity(G.lie_group, internal_value(g))
+is_identity(G::ValidationLieGroup, g) = is_identity(G.lie_group, unwrap_validation(g))
 function is_identity(
     G::ValidationLieGroup{𝔽,O}, e::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
@@ -469,7 +482,7 @@ function ManifoldsBase.is_point(
     kwargs...,
 )
     !_vLc(G, within, (:Point, context...)) && return true
-    return is_point(G.lie_group, internal_value(g); error=error, kwargs...)
+    return is_point(G.lie_group, unwrap_validation(g); error=error, kwargs...)
 end
 function ManifoldsBase.is_point(
     G::ValidationLieGroup,
@@ -492,35 +505,35 @@ function ManifoldsBase.is_point(
 ) where {𝔽,O<:AbstractGroupOperation}
     vG = base_lie_group(𝔤)
     !_vLc(vG, within, (:Vector, context...)) && return true
-    return is_point(LieAlgebra(vG.lie_group), internal_value(X); error=error, kwargs...)
+    return is_point(LieAlgebra(vG.lie_group), unwrap_validation(X); error=error, kwargs...)
 end
 function ManifoldsBase.is_vector(
     G::ValidationLieGroup{𝔽,O}, e::Identity{O}, X; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
-    return ManifoldsBase.is_vector(G.lie_group, e, internal_value(X); kwargs...)
+    return ManifoldsBase.is_vector(G.lie_group, e, unwrap_validation(X); kwargs...)
 end
 function ManifoldsBase.is_vector(G::ValidationLieGroup, g, X; kwargs...)
     return ManifoldsBase.is_vector(
-        G.lie_group, internal_value(g), internal_value(X); kwargs...
+        G.lie_group, unwrap_validation(g), unwrap_validation(X); kwargs...
     )
 end
 
 function ManifoldsBase.isapprox(G::ValidationLieGroup, g, h; kwargs...)
     is_point(G, g; within=isapprox, context=(:Input,), kwargs...)
     is_point(G, h; within=isapprox, context=(:Input,), kwargs...)
-    return isapprox(G.lie_group, internal_value(g), internal_value(h); kwargs...)
+    return isapprox(G.lie_group, unwrap_validation(g), unwrap_validation(h); kwargs...)
 end
 function ManifoldsBase.isapprox(
     G::ValidationLieGroup{𝔽,O}, g::Identity{O}, h; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     is_point(G, h; within=isapprox, context=(:Input,), kwargs...)
-    return isapprox(G.lie_group, g, internal_value(h); kwargs...)
+    return isapprox(G.lie_group, g, unwrap_validation(h); kwargs...)
 end
 function ManifoldsBase.isapprox(
     G::ValidationLieGroup{𝔽,O}, g, h::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     is_point(G, g; within=isapprox, context=(:Input,), kwargs...)
-    return isapprox(G.lie_group, internal_value(g), h; kwargs...)
+    return isapprox(G.lie_group, unwrap_validation(g), h; kwargs...)
 end
 function ManifoldsBase.isapprox(
     G::ValidationLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O}; kwargs...
@@ -536,8 +549,8 @@ function ManifoldsBase.isapprox(
     𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X, Y; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lie_group
-    _X = internal_value(X)
-    _Y = internal_value(Y)
+    _X = unwrap_validation(X)
+    _Y = unwrap_validation(Y)
     is_point(LieAlgebra(G), _X; within=isapprox, context=(:Input,), kwargs...)
     is_point(LieAlgebra(G), _Y; within=isapprox, context=(:Input,), kwargs...)
     return isapprox(LieAlgebra(G), _X, _Y; kwargs...)
@@ -552,7 +565,7 @@ function jacobian_conjugate(
 )
     is_point(G, g; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
     is_point(G, h; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
-    J = jacobian_conjugate(G.lie_group, internal_value(g), internal_value(h), args...)
+    J = jacobian_conjugate(G.lie_group, unwrap_validation(g), unwrap_validation(h), args...)
     return J
 end
 function jacobian_conjugate!(
@@ -565,13 +578,47 @@ function jacobian_conjugate!(
 )
     is_point(G, g; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
     is_point(G, h; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
-    jacobian_conjugate!(G.lie_group, J, internal_value(g), internal_value(h), args...)
+    jacobian_conjugate!(G.lie_group, J, unwrap_validation(g), unwrap_validation(h), args...)
     return J
 end
 
+function lie_bracket(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X, Y; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
+    Z = lie_bracket(LieAlgebra(G), unwrap_validation(X), unwrap_validation(Y))
+    is_point(𝔤, Z; widthin=lie_bracket, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(Z)
+end
+function lie_bracket!(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, Z, X, Y; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
+    lie_bracket!(
+        LieAlgebra(G), unwrap_validation(Z), unwrap_validation(X), unwrap_validation(Y)
+    )
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Output,), kwargs...)
+    return Z
+end
+function lie_bracket!(
+    𝔤::LieAlgebra{𝔽,AdditionGroupOperation,<:ValidationLieGroup}, Z, X, Y; kwargs...
+) where {𝔽}
+    G = base_lie_group(𝔤).lie_group
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
+    lie_bracket!(
+        LieAlgebra(G), unwrap_validation(Z), unwrap_validation(X), unwrap_validation(Y)
+    )
+    is_point(𝔤, X; widthin=lie_bracket, context=(:Output,), kwargs...)
+    return Z
+end
 function Base.log(G::ValidationLieGroup, g; kwargs...)
     is_point(G, g; widthin=log, context=(:Input,), kwargs...)
-    X = log(G.lie_group, internal_value(g))
+    X = log(G.lie_group, unwrap_validation(g))
     is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(X)
 end
@@ -592,7 +639,7 @@ end
 
 function ManifoldsBase.log!(G::ValidationLieGroup, X, g; kwargs...)
     is_point(G, g; widthin=log, context=(:Input,), kwargs...)
-    log!(G.lie_group, internal_value(X), internal_value(g))
+    log!(G.lie_group, unwrap_validation(X), unwrap_validation(g))
     is_point(LieAlgebra(G), X; widthin=log, context=(:Input,), kwargs...)
     return X
 end
@@ -606,7 +653,7 @@ end
 function ManifoldsBase.log!(G::ValidationLieGroup, X, g, h; kwargs...)
     is_point(G, g; widthin=log, context=(:Input,), kwargs...)
     is_point(G, h; widthin=log, context=(:Input,), kwargs...)
-    log!(G.lie_group, internal_value(X), internal_value(g), internal_value(h))
+    log!(G.lie_group, unwrap_validation(X), unwrap_validation(g), unwrap_validation(h))
     is_point(LieAlgebra(G), X; widthin=log, context=(:Input,), kwargs...)
     return X
 end
@@ -616,7 +663,7 @@ function LinearAlgebra.norm(
 ) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lie_group
     is_point(𝔤, X; within=norm, context=(:Input,), kwargs...)
-    return norm(LieAlgebra(G), internal_value(X))
+    return norm(LieAlgebra(G), unwrap_validation(X))
 end
 
 function Base.rand(G::ValidationLieGroup; vector_at=nothing, kwargs...)
@@ -624,6 +671,29 @@ function Base.rand(G::ValidationLieGroup; vector_at=nothing, kwargs...)
         is_point(G, vector_at; within=rand, context=(:Input,), kwargs...)
     end
     gX = rand(G.lie_group; vector_at=vector_at, kwargs...)
+    if vector_at !== nothing
+        is_point(LieAlgebra(G), gX; within=rand, context=(:Output,), kwargs...)
+    else
+        is_point(G, gX; within=rand, context=(:Output,), kwargs...)
+    end
+    return gX
+end
+
+function Random.rand!(
+    rng::AbstractRNG, G::ValidationLieGroup, gX; vector_at=nothing, kwargs...
+)
+    if vector_at !== nothing
+        is_point(G, vector_at; within=rand, context=(:Input,), kwargs...)
+        rand!(
+            rng,
+            G.lie_group,
+            unwrap_validation(gX);
+            vector_at=unwrap_validation(vector_at),
+            kwargs...,
+        )
+    else
+        rand!(rng, G.lie_group, unwrap_validation(gX); kwargs...)
+    end
     if vector_at !== nothing
         is_point(LieAlgebra(G), gX; within=rand, context=(:Output,), kwargs...)
     else
@@ -653,14 +723,14 @@ function vee(
 ) where {𝔽,O<:AbstractGroupOperation}
     is_point(𝔤, X; widthin=vee, context=(:Input,), kwargs...)
     G = base_lie_group(𝔤).lie_group
-    return vee(LieAlgebra(G), internal_value(X))
+    return vee(LieAlgebra(G), unwrap_validation(X))
 end
 function vee!(
     𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, c, X; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     is_point(𝔤, X; widthin=vee, context=(:Input,), kwargs...)
     G = base_lie_group(𝔤).lie_group
-    vee!(LieAlgebra(G), internal_value(c), internal_value(X))
+    vee!(LieAlgebra(G), unwrap_validation(c), unwrap_validation(X))
     return X
 end
 
@@ -687,6 +757,6 @@ function ManifoldsBase.zero_vector!(
     𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X::T
 ) where {𝔽,O<:AbstractGroupOperation,T}
     G = base_lie_group(𝔤).lie_group
-    T2 = typeof(internal_value(X))
+    T2 = typeof(unwrap_validation(X))
     return ValidationLieAlgebraTangentVector(zero_vector(G, T2))
 end

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -393,11 +393,6 @@ function identity_element!(G::ValidationLieGroup, g; kwargs...)
     is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
     return g
 end
-function identity_element!(G::ValidationLieGroup, g::AbstractMatrix; kwargs...)
-    identity_element!(G.lie_group, g)
-    is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
-    return g
-end
 
 function Base.inv(G::ValidationLieGroup, g; kwargs...)
     is_point(G, g; widthin=inv, context=(:Input,), kwargs...)

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -604,18 +604,7 @@ function lie_bracket!(
     is_point(𝔤, X; widthin=lie_bracket, context=(:Output,), kwargs...)
     return Z
 end
-function lie_bracket!(
-    𝔤::LieAlgebra{𝔽,AdditionGroupOperation,<:ValidationLieGroup}, Z, X, Y; kwargs...
-) where {𝔽}
-    G = base_lie_group(𝔤).lie_group
-    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
-    is_point(𝔤, X; widthin=lie_bracket, context=(:Input,), kwargs...)
-    lie_bracket!(
-        LieAlgebra(G), unwrap_validation(Z), unwrap_validation(X), unwrap_validation(Y)
-    )
-    is_point(𝔤, X; widthin=lie_bracket, context=(:Output,), kwargs...)
-    return Z
-end
+
 function Base.log(G::ValidationLieGroup, g; kwargs...)
     is_point(G, g; widthin=log, context=(:Input,), kwargs...)
     X = log(G.lie_group, unwrap_validation(g))
@@ -664,6 +653,13 @@ function LinearAlgebra.norm(
     G = base_lie_group(𝔤).lie_group
     is_point(𝔤, X; within=norm, context=(:Input,), kwargs...)
     return norm(LieAlgebra(G), unwrap_validation(X))
+end
+function LinearAlgebra.norm(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X::Real; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    is_point(𝔤, X; within=norm, context=(:Input,), kwargs...)
+    return norm(LieAlgebra(G), X)
 end
 
 function Base.rand(G::ValidationLieGroup; vector_at=nothing, kwargs...)

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -579,7 +579,7 @@ function Base.rand(G::ValidationLieGroup; vector_at=nothing, kwargs...)
     if vector_at !== nothing
         is_point(G, vector_at; within=rand, context=(:Input,), kwargs...)
     end
-    gX = rand(G.manifold; vector_at=vector_at, kwargs...)
+    gX = rand(G.lie_group; vector_at=vector_at, kwargs...)
     if vector_at !== nothing
         is_point(LieAlgebra(G), gX; within=rand, context=(:Output,), kwargs...)
     else

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -5,27 +5,460 @@ A Lie group to add tests to input parameters and ouptut values of functions defi
 for [`LieGroups`](@ref).
 
 
+Using the `ignore_contexts` keyword allows to specify a single `Symbol` or a vector of `Symbols`
+Of which contexts to ignore.
+
+Current contexts are
+* `:All`: disable all checks
+* `:Point`: checks for points
+* `:Algebra`: checks related to the [`LieAlgebra`](@ref)
+* `:Output`: checks for output
+* `:Input`: checks for input variables
+
 # Fields
 
 * `lie_group::L` the [`AbstractLieGroup`](@ref) to be decorated
 * ``
 
 # Constructor
-    ValidationLieGroup(L::AbstractLieGroup; )
+    ValidationLieGroup(L::AbstractLieGroup, check_manifold=true; kwargs...)
 
-Generate the Validation Lie Group for the given [`AbstractLieGroup`](@ref)  `L`
-
-    ValidationLieGroup(M::AbstractManifold, op::AbstractGroupOperation; kwargs...)
-
-Generate the Validation Lie Group for the given [`AbstractLieGroup`](@ref)  `L` based on
-a the [`ValidationManifold`](@extref) of `M` and a group operation `op`, that is, also on the
-manifold operations can be tested. suitable keywords are passed down.
+Generate the Validation Lie Group for the given [`AbstractLieGroup`](@ref) `L`.
+If `check_manifold` is set to `true` the inner manifold is additionally wrapped
+in a [`ValidationManifold`](@exref `ManifoldsBase.ValidationManifold`).
+All suitable keywords are passed to the constructor of the validation manifold as well.
 
 # Keyword arguments
 
-For the second constructor, all further keywords are passed to the [`ValidationManifold`](@ref) as well.
+* `error::Symbol=:error`: specify how errors in the validation should be reported.
+  this is passed to [`is_point`](@ref) and [`is_vector`](@ref) as the `error` keyword argument.
+  Available values are `:error`, `:warn`, `:info`, and `:none`. Every other value is treated as `:none`.
+* `ignore_contexts = Vector{Symbol}()` a vector to indicate which validation contexts should not be performed.
+* `ignore_functions=Dict{Function,Union{Symbol,Vector{Symbol}}}()` a dictionary to disable certain contexts within functions.
+  The key here is the non-mutating function variant (if it exists). The contexts are the same as in `ignore_contexts`.
 """
-struct ValidationLieGroup{𝔽, L<:LieGroup{𝔽}}
+struct ValidationLieGroup{
+    𝔽,
+    O<:AbstractGroupOperation,
+    M<:ManifoldsBase.AbstractManifold{𝔽},
+    L<:LieGroup{𝔽,O,M},
+    D<:Dict{<:Function,<:Union{Symbol,<:AbstractVector{Symbol}}},
+    V<:AbstractVector{Symbol},
+} <: AbstractLieGroup{𝔽,O,M}
     lie_group::L
-    mode::S
+    mode::Symbol
+    ignore_functions::D
+    ignore_contexts::V
 end
+function ValidationLieGroup(
+    L::LieGroup,
+    check_manifold::Bool=true;
+    error::Symbol=:error,
+    ignore_functions::D=Dict{Function,Union{Symbol,<:Vector{Symbol}}}(),
+    ignore_contexts::V=Vector{Symbol}(),
+) where {
+    D<:Dict{<:Function,<:Union{Symbol,<:AbstractVector{Symbol}}},V<:AbstractVector{Symbol}
+}
+    if check_manifold
+        M = ManifoldBase.ValidationManifold(
+            L.manifold;
+            error=error,
+            ignore_functions=ignore_functions,
+            ignore_contexts=ignore_contexts,
+        )
+        _lie_group = LieGroup(L.op, M)
+    else
+        _lie_group = L
+    end
+    return ValidationLieGroup(L, error, ignore_functions, ignore_contexts)
+end
+
+struct ValidationLieAlgebraTangentVector{T} <: AbstractLieAlgebraTangentVector
+    value::T
+end
+ManifoldsBase.internal_value(X::ValidationLieAlgebraTangentVector) = X.value
+ManifoldsBase.@manifold_vector_forwards ValidationLieAlgebraTangentVector value
+@default_lie_group_fallbacks ValidationLieGroup AbstractGroupOperation ManifoldsBase.ValidationMPoint ValidationLieAlgebraTangentVector value value
+
+#
+#
+# An access helper function
+
+"""
+    _vLc(M::ValidationLieGroup, f::Function, context::Symbol)
+    _vLc(M::ValidationLieGroup, f::Function, context::NTuple{N,Symbol}) where {N}
+
+Return whether a check should be performed within `f` and the `context`(`s`) provided.
+
+This function returns false and hence indicates not to check, when
+* (one of the) `context`(`s`) is in the ignore list for `f` within `ignore_functions`
+* (one of the) `context`(`s`) is in the `ignore_contexts` list
+
+Otherwise the test is active.
+
+!!! Note
+   This function is internal and used very often, so it has a very short name;
+    `_vLc` stands for "`ValidationLieGroup` check".
+"""
+function _vLc end
+
+function _vLc(G::ValidationLieGroup, ::Nothing, context::Symbol)
+    # Similarly for the global contexts
+    (:All ∈ G.ignore_contexts) && return false
+    (context ∈ G.ignore_contexts) && return false
+    return true
+end
+function _vLc(G::ValidationLieGroup, f::Function, context::Symbol)
+    if haskey(G.ignore_functions, f)
+        # If :All is present -> deactivate
+        !_vLc(G.ignore_functions[f], :All) && return false
+        # If any of the provided contexts is present -> deactivate
+        !_vLc(G.ignore_functions[f], context) && return false
+    end
+    !_vLc(G, nothing, context) && return false
+    return true
+end
+function _vLc(G::ValidationLieGroup, f, contexts::NTuple{N,Symbol}) where {N}
+    for c in contexts
+        !_vLc(G, f, c) && return false
+    end
+    return true
+end
+# Sub tests: is any of a in b? Then return false – b is from before always a symbol already
+# If a and b are symbols, equality is checked
+_vLc(a::Symbol, b::Symbol) = !(a === b)
+# If a is a vector multiple, then return false if b appears in a
+_vLc(a::Union{<:NTuple{N,Symbol} where {N},<:AbstractVector{Symbol}}, b::Symbol) = !(b ∈ a)
+
+"""
+    _msg(G::ValidationLieGroup, str; error=:None, within::Union{Nothing,<:Function} = nothing,
+    context::Union{NTuple{N,Symbol} where N} = NTuple{0,Symbol}())
+
+issue a message `str` according to the mode `mode` (as `@error`, `@warn`, `@info`).
+"""
+function _msg(
+    G::ValidationLieGroup,
+    str;
+    error=G.mode,
+    within::Union{Nothing,<:Function}=nothing,
+    context::Union{NTuple{N,Symbol} where N}=NTuple{0,Symbol}(),
+)
+    !_vLc(G, within, context) && return nothing
+    (error === :error) && (throw(ErrorException(str)))
+    (error === :warn) && (@warn str)
+    (error === :info) && (@info str)
+    return nothing
+end
+function ManifoldsBase._msg(
+    G::ValidationLieGroup,
+    err::Union{DomainError,ArgumentError,ErrorException};
+    error=G.mode,
+    within::Union{Nothing,<:Function}=nothing,
+    context::Union{NTuple{N,Symbol} where N}=NTuple{0,Symbol}(),
+)
+    !_vLc(G, within, context) && return nothing
+    (error === :error) && (throw(err))
+    (error === :warn) && (@warn "$err")
+    (error === :info) && (@info "$err")
+    return nothing
+end
+
+#
+#
+# Implement all of the interface but include checks
+Identity(VG::ValidationLieGroup) = Identity(VG.lie_group)
+
+function Base.adjoint(G::ValidationLieGroup, g, X; kwargs...)
+    is_point(G, g; widthin=adjoint, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=adjoint, contect=(:Input,), kwargs...)
+    Y = adjoint(G.lie_group, internal_value(g), internal_value(X))
+    is_point(LieAlgebra(G), Y; widthin=adjoint, contect=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(Y)
+end
+function adjoint!(G::ValidationLieGroup, Y, g, X; kwargs...)
+    is_point(G, g; widthin=adjoint, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=adjoint, contect=(:Input,), kwargs...)
+    adjoint!(G.lie_group, internal_value(Y), internal_value(g), internal_value(X))
+    is_point(LieAlgebra(G), Y; widthin=adjoint, contect=(:Output,), kwargs...)
+    return Y
+end
+
+Manifolds.base_manifold(G::ValidationLieGroup) = base_manifold(G.lie_group)
+
+function _compose(G::ValidationLieGroup, g, h; kwargs...)
+    is_point(G, g; widthin=compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=compose, contect=(:Input,), kwargs...)
+    k = compose(G.lie_group, internal_value(g), internal_value(h))
+    is_point(G, k; widthin=compose, contect=(:Output,), kwargs...)
+    return ValidationMPoint(k)
+end
+function _compose!(G::ValidationLieGroup, k, g, h; kwargs...)
+    is_point(G, g; widthin=compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=compose, contect=(:Input,), kwargs...)
+    compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    is_point(G, k; widthin=compose, contect=(:Output,), kwargs...)
+    return k
+end
+
+function conjugate(G::ValidationLieGroup, g, h; kwargs...)
+    is_point(G, g; widthin=conjugate, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=conjugate, contect=(:Input,), kwargs...)
+    k = conjugate(G.lie_group, internal_value(g), internal_value(h))
+    is_point(G, k; widthin=conjugate, contect=(:Output,), kwargs...)
+    return ValidationMPoint(k)
+end
+function conjugate!(G::ValidationLieGroup, k, g, h; kwargs...)
+    is_point(G, g; widthin=conjugate, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=conjugate, contect=(:Input,), kwargs...)
+    conjugate!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    is_point(G, k; widthin=conjugate, contect=(:Output,), kwargs...)
+    return k
+end
+
+function diff_conjugate(G::ValidationLieGroup, g, h, X; kwargs...)
+    is_point(G, g; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    Y = diff_conjugate(G.lie_group, internal_value(g), internal_value(h), internal_value(X))
+    is_point(LieAlgebra(G), Y; widthin=diff_conjugate, contect=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(Y)
+end
+function diff_conjugate!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
+    is_point(G, g; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    diff_conjugate!(
+        G.lie_group,
+        internal_value(Y),
+        internal_value(g),
+        internal_value(h),
+        internal_value(X),
+    )
+    is_point(LieAlgebra(G), Y; widthin=diff_conjugate, contect=(:Output,), kwargs...)
+    return Y
+end
+
+function diff_inv(G::ValidationLieGroup, g, X; kwargs...)
+    is_point(G, g; widthin=diff_inv, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_inv, contect=(:Input,), kwargs...)
+    Y = diff_inv(G.lie_group, internal_value(g), internal_value(X))
+    is_point(LieAlgebra(G), Y; widthin=diff_inv, contect=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(Y)
+end
+function diff_inv!(G::ValidationLieGroup, Y, h, X; kwargs...)
+    is_point(G, g; widthin=diff_inv, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_inv, contect=(:Input,), kwargs...)
+    diff_inv!(G.lie_group, internal_value(Y), internal_value(g), internal_value(X))
+    is_point(LieAlgebra(G), Y; widthin=diff_inv, contect=(:Output,), kwargs...)
+    return Y
+end
+
+function diff_left_compose(G::ValidationLieGroup, g, h, X; kwargs...)
+    is_point(G, g; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    Y = diff_left_compose(
+        G.lie_group, internal_value(g), internal_value(h), internal_value(X)
+    )
+    is_point(LieAlgebra(G), Y; widthin=diff_left_compose, contect=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(Y)
+end
+function diff_left_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
+    is_point(G, g; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    diff_left_compose!(
+        G.lie_group,
+        internal_value(Y),
+        internal_value(g),
+        internal_value(h),
+        internal_value(X),
+    )
+    is_point(LieAlgebra(G), Y; widthin=diff_left_compose, contect=(:Output,), kwargs...)
+    return Y
+end
+
+function diff_right_compose(G::ValidationLieGroup, g, h, X; kwargs...)
+    is_point(G, g; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    Y = diff_right_compose(
+        G.lie_group, internal_value(g), internal_value(h), internal_value(X)
+    )
+    is_point(LieAlgebra(G), Y; widthin=diff_right_compose, contect=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(Y)
+end
+function diff_right_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
+    is_point(G, g; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    diff_right_compose!(
+        G.lie_group,
+        internal_value(Y),
+        internal_value(g),
+        internal_value(h),
+        internal_value(X),
+    )
+    is_point(LieAlgebra(G), Y; widthin=diff_right_compose, contect=(:Output,), kwargs...)
+    return Y
+end
+
+function Base.exp(G::ValidationLieGroup, X; kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    g = exp(G.lie_group, internal_value(X))
+    is_point(G, g; widthin=exp, contect=(:Output,), kwargs...)
+    return ValidationMPoint(g)
+end
+function ManifoldsBase.exp!(G::ValidationLieGroup, g, X; kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    exp!(G.lie_group, internal_value(g), internal_value(X))
+    is_point(G, g; widthin=exp, contect=(:Output,), kwargs...)
+    return g
+end
+
+function Base.exp(G::ValidationLieGroup, g, X; kwargs...)
+    is_point(G, g; widthin=exp, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    h = exp(G.lie_group, internal_value(g), internal_value(X))
+    is_point(G, h; widthin=exp, contect=(:Output,), kwargs...)
+    return ValidationMPoint(h)
+end
+function ManifoldsBase.exp!(G::ValidationLieGroup, h, g, X; kwargs...)
+    is_point(G, g; widthin=exp, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    exp!(G.lie_group, internal_value(h), internal_value(g), internal_value(X))
+    is_point(G, h; widthin=exp, contect=(:Output,), kwargs...)
+    return g
+end
+
+function identity_element(G::ValidationLieGroup; kwargs...)
+    g = identity_element(G.lie_group)
+    is_point(G, g; widthin=identity_element, contect=(:Output,), kwargs...)
+    return ValidationMPoint(g)
+end
+
+function identity_element!(G::ValidationLieGroup, g; kwargs...)
+    identity_element!(G.lie_group, internal_value(g))
+    is_point(G, g; widthin=identity_element, contect=(:Output,), kwargs...)
+    return g
+end
+
+function Base.inv(G::ValidationLieGroup, g; kwargs...)
+    is_point(G, g; widthin=inv, contect=(:Input,), kwargs...)
+    h = inv(G.lie_group, internal_value(g))
+    is_point(G, h; widthin=inv, contect=(:Output,), kwargs...)
+    return ValidationMPoint(h)
+end
+function inv!(G::ValidationLieGroup, h, g; kwargs...)
+    is_point(G, g; widthin=inv, contect=(:Input,), kwargs...)
+    inv!(G.lie_group, internal_value(h), internal_value(g))
+    is_point(G, h; widthin=inv, contect=(:Output,), kwargs...)
+    return h
+end
+
+function inv_left_compose(G::ValidationLieGroup, g, h; kwargs...)
+    is_point(G, g; widthin=inv_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_left_compose, contect=(:Input,), kwargs...)
+    k = inv_left_compose(G.lie_group, internal_value(g), internal_value(h))
+    is_point(G, k; widthin=inv_left_compose, contect=(:Output,), kwargs...)
+    return ValidationMPoint(k)
+end
+function inv_left_compose!(G::ValidationLieGroup, k, g, h; kwargs...)
+    is_point(G, g; widthin=inv_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_left_compose, contect=(:Input,), kwargs...)
+    inv_left_compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    is_point(G, k; widthin=inv_left_compose, contect=(:Output,), kwargs...)
+    return k
+end
+
+function inv_right_compose(G::ValidationLieGroup, g, h; kwargs...)
+    is_point(G, g; widthin=inv_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_right_compose, contect=(:Input,), kwargs...)
+    k = inv_right_compose(G.lie_group, internal_value(g), internal_value(h))
+    is_point(G, k; widthin=inv_right_compose, contect=(:Output,), kwargs...)
+    return ValidationMPoint(k)
+end
+function inv_right_compose!(G::ValidationLieGroup, k, g, h; kwargs...)
+    is_point(G, g; widthin=inv_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_right_compose, contect=(:Input,), kwargs...)
+    inv_right_compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
+    is_point(G, k; widthin=inv_right_compose, contect=(:Output,), kwargs...)
+    return k
+end
+
+is_identity(G::ValidationLieGroup, g) = is_identity(G.lie_group, internal_value(g))
+
+function ManifoldsBase.is_point(G::ValidationLieGroup, g; kwargs...)
+    return is_point(G.lie_group, internal_value(g); kwargs...)
+end
+function ManifoldsBase.is_point(G::ValidationLieGroup, e::Identity; kwargs...)
+    return is_point(G.lie_group, e; kwargs...)
+end
+function ManifoldsBase.is_point(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lieGroup
+    return is_point(LieAlgebra(G), internal_value(X); kwargs...)
+end
+
+function ManifoldsBase.isapprox(G::ValidationLieGroup, g, h; kwargs...)
+    return isapprox(G.lie_group, internal_value(g), internal_value(h), h; kwargs...)
+end
+
+function jacobian_conjugate(G::ValidationLieGroup, g, h, args...; kwargs...)
+    is_point(G, g; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
+    J = jacobian_conjugate(G.lie_group, internal_value(g), internal_value(h), args...)
+    return J
+end
+function jacobian_conjugate!(G::ValidationLieGroup, J, g, h, args...; kwargs...)
+    is_point(G, g; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
+    jacobian_conjugate!(G.lie_group, J, internal_value(g), internal_value(h), args...)
+    return J
+end
+
+function Base.log(G::ValidationLieGroup, g; kwargs...)
+    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
+    X = log(G.lie_group, internal_value(g))
+    is_point(LieAlgebra(G), X; widthin=log, contect=(:Output,), kwargs...)
+    return ValidationMPoint(h)
+end
+function ManifoldsBase.log!(G::ValidationLieGroup, X, g; kwargs...)
+    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
+    log!(G.lie_group, internal_value(X), internal_value(g))
+    is_point(LieAlgebra(G), X; widthin=log, contect=(:Input,), kwargs...)
+    return X
+end
+
+function Base.log(G::ValidationLieGroup, g, h; kwargs...)
+    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=log, contect=(:Input,), kwargs...)
+    X = log(G.lie_group, internal_value(g), internal_value(h))
+    is_point(LieAlgebra(G), X; widthin=log, contect=(:Output,), kwargs...)
+    return ValidationMPoint(h)
+end
+function ManifoldsBase.log!(G::ValidationLieGroup, X, g, h; kwargs...)
+    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
+    is_point(G, h; widthin=log, contect=(:Input,), kwargs...)
+    log!(G.lie_group, internal_value(X), internal_value(g), internal_value(h))
+    is_point(LieAlgebra(G), X; widthin=log, contect=(:Input,), kwargs...)
+    return X
+end
+
+function Base.rand(G::ValidationLieGroup; vector_at=nothing, kwargs...)
+    if vector_at !== nothing
+        is_point(G, vector_at; within=rand, context=(:Input,), kwargs...)
+    end
+    gX = rand(G.manifold; vector_at=vector_at, kwargs...)
+    if vector_at !== nothing
+        is_point(LieAlgebra(G), gX; within=rand, context=(:Output,), kwargs...)
+    else
+        is_point(G, gX; within=rand, context=(:Output,), kwargs...)
+    end
+    return gX
+end
+
+ManifoldsBase.manifold_dimension(G::ValidationLieGroup) = manifold_dimension(G.lie_group)
+
+ManifoldsBase.representation_size(G::ValidationLieGroup) = representation_size(G.lie_group)

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -169,64 +169,64 @@ end
 Identity(VG::ValidationLieGroup) = Identity(VG.lie_group)
 
 function Base.adjoint(G::ValidationLieGroup, g, X; kwargs...)
-    is_point(G, g; widthin=adjoint, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=adjoint, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=adjoint, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=adjoint, context=(:Input,), kwargs...)
     Y = adjoint(G.lie_group, internal_value(g), internal_value(X))
-    is_point(LieAlgebra(G), Y; widthin=adjoint, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=adjoint, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
 end
 function adjoint!(G::ValidationLieGroup, Y, g, X; kwargs...)
-    is_point(G, g; widthin=adjoint, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=adjoint, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=adjoint, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=adjoint, context=(:Input,), kwargs...)
     adjoint!(G.lie_group, internal_value(Y), internal_value(g), internal_value(X))
-    is_point(LieAlgebra(G), Y; widthin=adjoint, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=adjoint, context=(:Output,), kwargs...)
     return Y
 end
 
 Manifolds.base_manifold(G::ValidationLieGroup) = base_manifold(G.lie_group)
 
 function _compose(G::ValidationLieGroup, g, h; kwargs...)
-    is_point(G, g; widthin=compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=compose, context=(:Input,), kwargs...)
     k = compose(G.lie_group, internal_value(g), internal_value(h))
-    is_point(G, k; widthin=compose, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=compose, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function _compose!(G::ValidationLieGroup, k, g, h; kwargs...)
-    is_point(G, g; widthin=compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=compose, context=(:Input,), kwargs...)
     compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
-    is_point(G, k; widthin=compose, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=compose, context=(:Output,), kwargs...)
     return k
 end
 
 function conjugate(G::ValidationLieGroup, g, h; kwargs...)
-    is_point(G, g; widthin=conjugate, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=conjugate, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=conjugate, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=conjugate, context=(:Input,), kwargs...)
     k = conjugate(G.lie_group, internal_value(g), internal_value(h))
-    is_point(G, k; widthin=conjugate, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=conjugate, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function conjugate!(G::ValidationLieGroup, k, g, h; kwargs...)
-    is_point(G, g; widthin=conjugate, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=conjugate, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=conjugate, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=conjugate, context=(:Input,), kwargs...)
     conjugate!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
-    is_point(G, k; widthin=conjugate, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=conjugate, context=(:Output,), kwargs...)
     return k
 end
 
 function diff_conjugate(G::ValidationLieGroup, g, h, X; kwargs...)
-    is_point(G, g; widthin=diff_conjugate, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=diff_conjugate, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_conjugate, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_conjugate, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_conjugate, context=(:Input,), kwargs...)
     Y = diff_conjugate(G.lie_group, internal_value(g), internal_value(h), internal_value(X))
-    is_point(LieAlgebra(G), Y; widthin=diff_conjugate, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_conjugate, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
 end
 function diff_conjugate!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
-    is_point(G, g; widthin=diff_conjugate, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=diff_conjugate, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_conjugate, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_conjugate, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_conjugate, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_conjugate, context=(:Input,), kwargs...)
     diff_conjugate!(
         G.lie_group,
         internal_value(Y),
@@ -234,39 +234,32 @@ function diff_conjugate!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
         internal_value(h),
         internal_value(X),
     )
-    is_point(LieAlgebra(G), Y; widthin=diff_conjugate, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_conjugate, context=(:Output,), kwargs...)
     return Y
 end
 
-function diff_inv(G::ValidationLieGroup, g, X; kwargs...)
-    is_point(G, g; widthin=diff_inv, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_inv, contect=(:Input,), kwargs...)
-    Y = diff_inv(G.lie_group, internal_value(g), internal_value(X))
-    is_point(LieAlgebra(G), Y; widthin=diff_inv, contect=(:Output,), kwargs...)
-    return ValidationLieAlgebraTangentVector(Y)
-end
 function diff_inv!(G::ValidationLieGroup, Y, h, X; kwargs...)
-    is_point(G, g; widthin=diff_inv, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_inv, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_inv, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_inv, context=(:Input,), kwargs...)
     diff_inv!(G.lie_group, internal_value(Y), internal_value(g), internal_value(X))
-    is_point(LieAlgebra(G), Y; widthin=diff_inv, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_inv, context=(:Output,), kwargs...)
     return Y
 end
 
 function diff_left_compose(G::ValidationLieGroup, g, h, X; kwargs...)
-    is_point(G, g; widthin=diff_left_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=diff_left_compose, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_left_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_left_compose, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_left_compose, context=(:Input,), kwargs...)
     Y = diff_left_compose(
         G.lie_group, internal_value(g), internal_value(h), internal_value(X)
     )
-    is_point(LieAlgebra(G), Y; widthin=diff_left_compose, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_left_compose, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
 end
 function diff_left_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
-    is_point(G, g; widthin=diff_left_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=diff_left_compose, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_left_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_left_compose, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_left_compose, context=(:Input,), kwargs...)
     diff_left_compose!(
         G.lie_group,
         internal_value(Y),
@@ -274,24 +267,24 @@ function diff_left_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
         internal_value(h),
         internal_value(X),
     )
-    is_point(LieAlgebra(G), Y; widthin=diff_left_compose, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_left_compose, context=(:Output,), kwargs...)
     return Y
 end
 
 function diff_right_compose(G::ValidationLieGroup, g, h, X; kwargs...)
-    is_point(G, g; widthin=diff_right_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=diff_right_compose, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_right_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_right_compose, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_right_compose, context=(:Input,), kwargs...)
     Y = diff_right_compose(
         G.lie_group, internal_value(g), internal_value(h), internal_value(X)
     )
-    is_point(LieAlgebra(G), Y; widthin=diff_right_compose, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_right_compose, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(Y)
 end
 function diff_right_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
-    is_point(G, g; widthin=diff_right_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=diff_right_compose, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=diff_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=diff_right_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=diff_right_compose, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=diff_right_compose, context=(:Input,), kwargs...)
     diff_right_compose!(
         G.lie_group,
         internal_value(Y),
@@ -299,150 +292,253 @@ function diff_right_compose!(G::ValidationLieGroup, Y, g, h, X; kwargs...)
         internal_value(h),
         internal_value(X),
     )
-    is_point(LieAlgebra(G), Y; widthin=diff_right_compose, contect=(:Output,), kwargs...)
+    is_point(LieAlgebra(G), Y; widthin=diff_right_compose, context=(:Output,), kwargs...)
     return Y
 end
 
 function Base.exp(G::ValidationLieGroup, X; kwargs...)
-    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
     g = exp(G.lie_group, internal_value(X))
-    is_point(G, g; widthin=exp, contect=(:Output,), kwargs...)
+    is_point(G, g; widthin=exp, context=(:Output,), kwargs...)
     return ValidationMPoint(g)
 end
 function ManifoldsBase.exp!(G::ValidationLieGroup, g, X; kwargs...)
-    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
     exp!(G.lie_group, internal_value(g), internal_value(X))
-    is_point(G, g; widthin=exp, contect=(:Output,), kwargs...)
+    is_point(G, g; widthin=exp, context=(:Output,), kwargs...)
     return g
 end
 
 function Base.exp(G::ValidationLieGroup, g, X; kwargs...)
-    is_point(G, g; widthin=exp, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=exp, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
     h = exp(G.lie_group, internal_value(g), internal_value(X))
-    is_point(G, h; widthin=exp, contect=(:Output,), kwargs...)
+    is_point(G, h; widthin=exp, context=(:Output,), kwargs...)
     return ValidationMPoint(h)
 end
 function ManifoldsBase.exp!(G::ValidationLieGroup, h, g, X; kwargs...)
-    is_point(G, g; widthin=exp, contect=(:Input,), kwargs...)
-    is_point(LieAlgebra(G), X; widthin=exp, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=exp, context=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=exp, context=(:Input,), kwargs...)
     exp!(G.lie_group, internal_value(h), internal_value(g), internal_value(X))
-    is_point(G, h; widthin=exp, contect=(:Output,), kwargs...)
+    is_point(G, h; widthin=exp, context=(:Output,), kwargs...)
     return g
 end
 
 function identity_element(G::ValidationLieGroup; kwargs...)
     g = identity_element(G.lie_group)
-    is_point(G, g; widthin=identity_element, contect=(:Output,), kwargs...)
+    is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
     return ValidationMPoint(g)
 end
 
 function identity_element!(G::ValidationLieGroup, g; kwargs...)
     identity_element!(G.lie_group, internal_value(g))
-    is_point(G, g; widthin=identity_element, contect=(:Output,), kwargs...)
+    is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
+    return g
+end
+function identity_element!(G::ValidationLieGroup, g::AbstractMatrix; kwargs...)
+    identity_element!(G.lie_group, g)
+    is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
     return g
 end
 
 function Base.inv(G::ValidationLieGroup, g; kwargs...)
-    is_point(G, g; widthin=inv, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=inv, context=(:Input,), kwargs...)
     h = inv(G.lie_group, internal_value(g))
-    is_point(G, h; widthin=inv, contect=(:Output,), kwargs...)
+    is_point(G, h; widthin=inv, context=(:Output,), kwargs...)
     return ValidationMPoint(h)
 end
+function Base.inv(
+    G::LieGroups.ValidationLieGroup{𝔽,O}, e::LieGroups.Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    is_identity(G.lie_group, e; kwargs...)
+    return ValidationMPoint(inv(G.lie_group, e))
+end
 function inv!(G::ValidationLieGroup, h, g; kwargs...)
-    is_point(G, g; widthin=inv, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=inv, context=(:Input,), kwargs...)
     inv!(G.lie_group, internal_value(h), internal_value(g))
-    is_point(G, h; widthin=inv, contect=(:Output,), kwargs...)
+    is_point(G, h; widthin=inv, context=(:Output,), kwargs...)
+    return h
+end
+function inv!(
+    G::ValidationLieGroup{𝔽,O}, h, e::LieGroups.Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    is_identity(G.lie_group, e; kwargs...)
+    inv!(G.lie_group, internal_value(h), e)
+    is_point(G, h; widthin=inv, context=(:Output,), kwargs...)
     return h
 end
 
 function inv_left_compose(G::ValidationLieGroup, g, h; kwargs...)
-    is_point(G, g; widthin=inv_left_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=inv_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=inv_left_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_left_compose, context=(:Input,), kwargs...)
     k = inv_left_compose(G.lie_group, internal_value(g), internal_value(h))
-    is_point(G, k; widthin=inv_left_compose, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=inv_left_compose, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function inv_left_compose!(G::ValidationLieGroup, k, g, h; kwargs...)
-    is_point(G, g; widthin=inv_left_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=inv_left_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=inv_left_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_left_compose, context=(:Input,), kwargs...)
     inv_left_compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
-    is_point(G, k; widthin=inv_left_compose, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=inv_left_compose, context=(:Output,), kwargs...)
     return k
 end
 
 function inv_right_compose(G::ValidationLieGroup, g, h; kwargs...)
-    is_point(G, g; widthin=inv_right_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=inv_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=inv_right_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_right_compose, context=(:Input,), kwargs...)
     k = inv_right_compose(G.lie_group, internal_value(g), internal_value(h))
-    is_point(G, k; widthin=inv_right_compose, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=inv_right_compose, context=(:Output,), kwargs...)
     return ValidationMPoint(k)
 end
 function inv_right_compose!(G::ValidationLieGroup, k, g, h; kwargs...)
-    is_point(G, g; widthin=inv_right_compose, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=inv_right_compose, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=inv_right_compose, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=inv_right_compose, context=(:Input,), kwargs...)
     inv_right_compose!(G.lie_group, internal_value(k), internal_value(g), internal_value(h))
-    is_point(G, k; widthin=inv_right_compose, contect=(:Output,), kwargs...)
+    is_point(G, k; widthin=inv_right_compose, context=(:Output,), kwargs...)
     return k
 end
 
 is_identity(G::ValidationLieGroup, g) = is_identity(G.lie_group, internal_value(g))
-
-function ManifoldsBase.is_point(G::ValidationLieGroup, g; kwargs...)
-    return is_point(G.lie_group, internal_value(g); kwargs...)
+function is_identity(
+    G::ValidationLieGroup{𝔽,O}, e::LieGroups.Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    return is_identity(G.lie_group, e)
 end
-function ManifoldsBase.is_point(G::ValidationLieGroup, e::Identity; kwargs...)
-    return is_point(G.lie_group, e; kwargs...)
+function is_identity(
+    G::ValidationLieGroup{𝔽,<:AbstractGroupOperation},
+    e::LieGroups.Identity{<:AbstractGroupOperation};
+    kwargs...,
+) where {𝔽}
+    return is_identity(G.lie_group, e)
 end
 function ManifoldsBase.is_point(
-    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X; kwargs...
+    G::ValidationLieGroup,
+    g;
+    error::Symbol=G.mode,
+    within::Union{Nothing,Function}=nothing,
+    context::NTuple{N,Symbol} where {N}=(),
+    kwargs...,
+)
+    !_vGc(G, within, (:Point, context...)) && return true
+    return is_point(G.lie_group, internal_value(g); error=error, kwargs...)
+end
+function ManifoldsBase.is_point(
+    G::ValidationLieGroup,
+    e::Identity;
+    error::Symbol=G.mode,
+    within::Union{Nothing,Function}=nothing,
+    context::NTuple{N,Symbol} where {N}=(),
+    kwargs...,
+)
+    !_vGc(G, within, (:Point, context...)) && return true
+    return is_point(G.lie_group, e; error=error, kwargs...)
+end
+function ManifoldsBase.is_point(
+    𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup},
+    X;
+    error::Symbol=base_lie_group(𝔤).mode,
+    within::Union{Nothing,Function}=nothing,
+    context::NTuple{N,Symbol} where {N}=(),
+    kwargs...,
 ) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lieGroup
-    return is_point(LieAlgebra(G), internal_value(X); kwargs...)
+    !_vGc(G, within, (:Vector, context...)) && return true
+    return is_point(LieAlgebra(G), internal_value(X); error=error, kwargs...)
 end
 
 function ManifoldsBase.isapprox(G::ValidationLieGroup, g, h; kwargs...)
-    return isapprox(G.lie_group, internal_value(g), internal_value(h), h; kwargs...)
+    is_point(G, g; within=isapprox, context=(:Input,), kwargs...)
+    is_point(G, h; within=isapprox, context=(:Input,), kwargs...)
+    return isapprox(G.lie_group, internal_value(g), internal_value(h); kwargs...)
+end
+function ManifoldsBase.isapprox(
+    G::ValidationLieGroup{𝔽,O}, g::Identity{O}, h; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    is_point(G, h; within=isapprox, context=(:Input,), kwargs...)
+    return isapprox(G.lie_group, g, internal_value(h); kwargs...)
+end
+function ManifoldsBase.isapprox(
+    G::ValidationLieGroup{𝔽,O}, g, h::Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    is_point(G, g; within=isapprox, context=(:Input,), kwargs...)
+    return isapprox(G.lie_group, internal_value(g), h; kwargs...)
+end
+function ManifoldsBase.isapprox(
+    G::ValidationLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    return isapprox(G.lie_group, g, h; kwargs...)
+end
+function ManifoldsBase.isapprox(
+    G::ValidationLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O2}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation,O2<:AbstractGroupOperation}
+    return isapprox(G.lie_group, g, h; kwargs...)
 end
 
-function jacobian_conjugate(G::ValidationLieGroup, g, h, args...; kwargs...)
-    is_point(G, g; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
+function jacobian_conjugate(
+    G::ValidationLieGroup,
+    g,
+    h,
+    B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis();
+    kwargs...,
+)
+    is_point(G, g; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
     J = jacobian_conjugate(G.lie_group, internal_value(g), internal_value(h), args...)
     return J
 end
-function jacobian_conjugate!(G::ValidationLieGroup, J, g, h, args...; kwargs...)
-    is_point(G, g; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=jacobian_conjugate, contect=(:Input,), kwargs...)
+function jacobian_conjugate!(
+    G::ValidationLieGroup,
+    J,
+    g,
+    h,
+    B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis();
+    kwargs...,
+)
+    is_point(G, g; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=jacobian_conjugate, context=(:Input,), kwargs...)
     jacobian_conjugate!(G.lie_group, J, internal_value(g), internal_value(h), args...)
     return J
 end
 
 function Base.log(G::ValidationLieGroup, g; kwargs...)
-    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=log, context=(:Input,), kwargs...)
     X = log(G.lie_group, internal_value(g))
-    is_point(LieAlgebra(G), X; widthin=log, contect=(:Output,), kwargs...)
-    return ValidationMPoint(h)
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
 end
-function ManifoldsBase.log!(G::ValidationLieGroup, X, g; kwargs...)
-    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
-    log!(G.lie_group, internal_value(X), internal_value(g))
-    is_point(LieAlgebra(G), X; widthin=log, contect=(:Input,), kwargs...)
-    return X
+function Base.log(
+    G::ValidationLieGroup{𝔽,O}, e::Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    X = log(G.lie_group, e)
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
+end
+function Base.log(
+    G::ValidationLieGroup{𝔽,O}, e::Identity{O}, T::Type; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    X = log(G.lie_group, e, T)
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
 end
 
-function Base.log(G::ValidationLieGroup, g, h; kwargs...)
-    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=log, contect=(:Input,), kwargs...)
-    X = log(G.lie_group, internal_value(g), internal_value(h))
-    is_point(LieAlgebra(G), X; widthin=log, contect=(:Output,), kwargs...)
-    return ValidationMPoint(h)
+function ManifoldsBase.log!(G::ValidationLieGroup, X, g; kwargs...)
+    is_point(G, g; widthin=log, context=(:Input,), kwargs...)
+    log!(G.lie_group, internal_value(X), internal_value(g))
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Input,), kwargs...)
+    return X
+end
+function ManifoldsBase.log!(
+    G::ValidationLieGroup{𝔽,O}, X, e::Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation}
+    log!(G.lie_group, X, e)
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
 end
 function ManifoldsBase.log!(G::ValidationLieGroup, X, g, h; kwargs...)
-    is_point(G, g; widthin=log, contect=(:Input,), kwargs...)
-    is_point(G, h; widthin=log, contect=(:Input,), kwargs...)
+    is_point(G, g; widthin=log, context=(:Input,), kwargs...)
+    is_point(G, h; widthin=log, context=(:Input,), kwargs...)
     log!(G.lie_group, internal_value(X), internal_value(g), internal_value(h))
-    is_point(LieAlgebra(G), X; widthin=log, contect=(:Input,), kwargs...)
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Input,), kwargs...)
     return X
 end
 

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -159,7 +159,7 @@ function _msg(
     (error === :info) && (@info str)
     return nothing
 end
-function ManifoldsBase._msg(
+function _msg(
     G::ValidationLieGroup,
     err::Union{DomainError,ArgumentError,ErrorException};
     error=G.mode,
@@ -539,6 +539,11 @@ function ManifoldsBase.isapprox(
 end
 function ManifoldsBase.isapprox(
     G::ValidationLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O2}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation,O2<:AbstractGroupOperation}
+    return isapprox(G.lie_group, g, h; kwargs...)
+end
+function ManifoldsBase.isapprox(
+    G::ValidationLieGroup{𝔽,O}, g::Identity{O2}, h::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation,O2<:AbstractGroupOperation}
     return isapprox(G.lie_group, g, h; kwargs...)
 end

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -25,13 +25,13 @@ Current contexts are
 
 Generate the Validation Lie Group for the given [`AbstractLieGroup`](@ref) `L`.
 If `check_manifold` is set to `true` the inner manifold is additionally wrapped
-in a [`ValidationManifold`](@exref `ManifoldsBase.ValidationManifold`).
+in a [`ValidationManifold`](@extref `ManifoldsBase.ValidationManifold`).
 All suitable keywords are passed to the constructor of the validation manifold as well.
 
 # Keyword arguments
 
 * `error::Symbol=:error`: specify how errors in the validation should be reported.
-  this is passed to [`is_point`](@ref) and [`is_vector`](@ref) as the `error` keyword argument.
+  this is passed to [`is_point`](@extref `ManifoldsBase.is_point`) and [`is_vector`](@extref `ManifoldsBase.is_vector`) as the `error` keyword argument.
   Available values are `:error`, `:warn`, `:info`, and `:none`. Every other value is treated as `:none`.
 * `ignore_contexts = Vector{Symbol}()` a vector to indicate which validation contexts should not be performed.
 * `ignore_functions=Dict{Function,Union{Symbol,Vector{Symbol}}}()` a dictionary to disable certain contexts within functions.

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -60,13 +60,13 @@ function ValidationLieGroup(
     D<:Dict{<:Function,<:Union{Symbol,<:AbstractVector{Symbol}}},V<:AbstractVector{Symbol}
 }
     if check_manifold
-        M = ManifoldBase.ValidationManifold(
+        M = ValidationManifold(
             L.manifold;
             error=error,
             ignore_functions=ignore_functions,
             ignore_contexts=ignore_contexts,
         )
-        _lie_group = LieGroup(L.op, M)
+        _lie_group = LieGroup(M, L.op)
     else
         _lie_group = L
     end
@@ -419,7 +419,7 @@ function ManifoldsBase.is_point(
     context::NTuple{N,Symbol} where {N}=(),
     kwargs...,
 )
-    !_vGc(G, within, (:Point, context...)) && return true
+    !_vLc(G, within, (:Point, context...)) && return true
     return is_point(G.lie_group, internal_value(g); error=error, kwargs...)
 end
 function ManifoldsBase.is_point(
@@ -430,7 +430,7 @@ function ManifoldsBase.is_point(
     context::NTuple{N,Symbol} where {N}=(),
     kwargs...,
 )
-    !_vGc(G, within, (:Point, context...)) && return true
+    !_vLc(G, within, (:Point, context...)) && return true
     return is_point(G.lie_group, e; error=error, kwargs...)
 end
 function ManifoldsBase.is_point(
@@ -442,7 +442,7 @@ function ManifoldsBase.is_point(
     kwargs...,
 ) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lieGroup
-    !_vGc(G, within, (:Vector, context...)) && return true
+    !_vLc(G, within, (:Vector, context...)) && return true
     return is_point(LieAlgebra(G), internal_value(X); error=error, kwargs...)
 end
 
@@ -558,3 +558,15 @@ end
 ManifoldsBase.manifold_dimension(G::ValidationLieGroup) = manifold_dimension(G.lie_group)
 
 ManifoldsBase.representation_size(G::ValidationLieGroup) = representation_size(G.lie_group)
+
+function Base.show(io::IO, G::ValidationLieGroup)
+    s = """
+    ValidationLieGroup of $(G.lie_group)
+        * mode = :$(G.mode)
+    """
+    G_ig = G.ignore_contexts
+    (length(G_ig) > 0) && (s *= "    * ignore_context = $(G_ig)\n")
+    G_if = G.ignore_functions
+    (length(G_if) > 0) && (s *= "    * ignore_functions = $(G_if)")
+    return print(io, s)
+end

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -81,6 +81,8 @@ ManifoldsBase.internal_value(X::ValidationLieAlgebraTangentVector) = X.value
 ManifoldsBase.@manifold_vector_forwards ValidationLieAlgebraTangentVector value
 @default_lie_group_fallbacks ValidationLieGroup AbstractGroupOperation ManifoldsBase.ValidationMPoint ValidationLieAlgebraTangentVector value value
 
+Identity(VG::ValidationLieGroup) = Identity(VG.lie_group)
+
 #
 #
 # An access helper function
@@ -167,7 +169,6 @@ end
 #
 #
 # Implement all of the interface but include checks
-Identity(VG::ValidationLieGroup) = Identity(VG.lie_group)
 
 function Base.adjoint(G::ValidationLieGroup, g, X; kwargs...)
     is_point(G, g; widthin=adjoint, context=(:Input,), kwargs...)
@@ -573,6 +574,12 @@ function ManifoldsBase.log!(G::ValidationLieGroup, X, g, h; kwargs...)
     log!(G.lie_group, internal_value(X), internal_value(g), internal_value(h))
     is_point(LieAlgebra(G), X; widthin=log, context=(:Input,), kwargs...)
     return X
+end
+
+function LinearAlgebra.norm(𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, X; kwargs...) where {𝔽, O<:AbstractGroupOperation}
+    G = base_lie_group(𝔤).lie_group
+    is_point(𝔤, X; within=rand, context=(:Input,), kwargs...)
+    return norm(LieAlgebra(G), internal_value(X))
 end
 
 function Base.rand(G::ValidationLieGroup; vector_at=nothing, kwargs...)

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -95,8 +95,10 @@ unwrap_validation(vP::ValidationMPoint) = vP.value
 """
     _vLc(M::ValidationLieGroup, f::Function, context::Symbol)
     _vLc(M::ValidationLieGroup, f::Function, context::NTuple{N,Symbol}) where {N}
+    _vLc(M::ValidationLieGroup, ::Nothing, context::NTuple{N,Symbol}) where {N}
 
-Return whether a check should be performed within `f` and the `context`(`s`) provided.
+Return whether a check should be performed within `f` and the `context`(`s`) provided,
+if the second argument is `:Nothing`, only the context is checked
 
 This function returns false and hence indicates not to check, when
 * (one of the) `context`(`s`) is in the ignore list for `f` within `ignore_functions`

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -18,7 +18,13 @@ Current contexts are
 # Fields
 
 * `lie_group::L` the [`AbstractLieGroup`](@ref) to be decorated
-* ``
+* `mode::Symbol`: The mode to be used for error handling, either `:error` or `:warn`
+* `ignore_contexts::AbstractVector{Symbol}`: store contexts to be ignored of validation.
+* `ignore_functions::Dict{<:Function,<:Union{Symbol,<:AbstractVector{Symbol}}`:
+  store contexts to be ignored with in a function or its mutating variant.
+
+where all but the first field are analogous to the setups of the [`ValidationManifold`](@extref `ManifoldsBase.ValidationManifold`).
+We refer to those docs for more examples on their meaning.
 
 # Constructor
     ValidationLieGroup(L::AbstractLieGroup, check_manifold=true; kwargs...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -666,7 +666,7 @@ end
 function jacobian_conjugate! end
 @doc "$(_doc_jacobian_conjugate)"
 jacobian_conjugate!(
-    ::AbstractLieGroup, J, g, h; B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis()
+    ::AbstractLieGroup, J, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis()
 )
 
 _doc_log = """
@@ -736,7 +736,7 @@ function ManifoldsBase.log(
     return zero_vector(LieAlgebra(G))
 end
 function ManifoldsBase.log(
-    G::AbstractLieGroup{𝔽,Op}, e::Identity{Op}, T::Type
+    G::AbstractLieGroup{𝔽,Op}, ::Identity{Op}, T::Type
 ) where {𝔽,Op<:AbstractGroupOperation}
     return zero_vector(LieAlgebra(G), T)
 end
@@ -745,8 +745,8 @@ end
 ManifoldsBase.log!(G::AbstractLieGroup, ::Any, ::Any)
 
 function ManifoldsBase.log!(
-    G::L, X, e::Identity{Op}
-) where {𝔽,Op<:AbstractGroupOperation,L<:AbstractLieGroup{𝔽,Op}}
+    G::AbstractLieGroup{𝔽,Op}, X, e::Identity{Op}
+) where {𝔽,Op<:AbstractGroupOperation}
     return zero_vector!(LieAlgebra(G), X)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -35,8 +35,8 @@ end
 An abstract type to represent Lie groups. For most cases it should suffice to “combine”
 an $(_link(:AbstractManifold)) with an [`AbstractGroupOperation`](@ref), see [`LieGroup`](@ref).
 """
-abstract type AbstractLieGroup{𝔽, O<:AbstractGroupOperation, M<:AbstractManifold{𝔽}} <: AbstractManifold{𝔽} end
-
+abstract type AbstractLieGroup{𝔽,O<:AbstractGroupOperation,M<:AbstractManifold{𝔽}} <:
+              AbstractManifold{𝔽} end
 
 """
     LieGroup{𝔽, O<:AbstractGroupOperation, M<:AbstractManifold{𝔽}} <:  AbstractLieGroup{𝔽, O, M}
@@ -213,10 +213,14 @@ function compose! end
 
 @doc "$(_doc_compose)"
 compose!(G::AbstractLieGroup, k, g, h) = _compose!(G, k, g, h)
-function compose!(G::AbstractLieGroup{𝔽,O}, k, ::Identity{O}, h) where {𝔽,O<:AbstractGroupOperation}
+function compose!(
+    G::AbstractLieGroup{𝔽,O}, k, ::Identity{O}, h
+) where {𝔽,O<:AbstractGroupOperation}
     return copyto!(G, k, h)
 end
-function compose!(G::AbstractLieGroup{𝔽,O}, k, g, ::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
+function compose!(
+    G::AbstractLieGroup{𝔽,O}, k, g, ::Identity{O}
+) where {𝔽,O<:AbstractGroupOperation}
     return copyto!(G, k, g)
 end
 function compose!(
@@ -476,11 +480,15 @@ function inv! end
 @doc "$_doc_inv"
 inv!(G::AbstractLieGroup, h, g)
 
-function Base.inv(::AbstractLieGroup{𝔽,O}, e::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
+function Base.inv(
+    ::AbstractLieGroup{𝔽,O}, e::Identity{O}
+) where {𝔽,O<:AbstractGroupOperation}
     return e
 end
 
-function inv!(G::AbstractLieGroup{𝔽,O}, g, ::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
+function inv!(
+    G::AbstractLieGroup{𝔽,O}, g, ::Identity{O}
+) where {𝔽,O<:AbstractGroupOperation}
     return identity_element!(G, g)
 end
 
@@ -580,7 +588,9 @@ function ManifoldsBase.is_point(
 ) where {𝔽,O<:AbstractGroupOperation}
     return true
 end
-function ManifoldsBase.is_point(G::AbstractLieGroup, e::Identity; error::Symbol=:none, kwargs...)
+function ManifoldsBase.is_point(
+    G::AbstractLieGroup, e::Identity; error::Symbol=:none, kwargs...
+)
     s = """
         The provided point $e is not the Identity on $G.
         Expected an Identity corresponding to $(G.op).
@@ -791,7 +801,9 @@ function Random.rand(G::AbstractLieGroup, T::Type; vector_at=nothing, kwargs...)
     rand!(G, gX; vector_at=vector_at, kwargs...)
     return gX
 end
-function Random.rand(rng::AbstractRNG, M::AbstractLieGroup, T::Type; vector_at=nothing, kwargs...)
+function Random.rand(
+    rng::AbstractRNG, M::AbstractLieGroup, T::Type; vector_at=nothing, kwargs...
+)
     if vector_at === nothing
         gX = allocate_on(M, T)
     else

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -638,7 +638,11 @@ function ManifoldsBase.isapprox(
 ) where {𝔽,O<:AbstractGroupOperation,O2<:AbstractGroupOperation}
     return false
 end
-
+function ManifoldsBase.isapprox(
+    G::AbstractLieGroup{𝔽,O}, g::Identity{O2}, h::Identity{O}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation,O2<:AbstractGroupOperation}
+    return false
+end
 _doc_jacobian_conjugate = """
     jacobian_conjugate(G::AbstractLieGroup, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis())
     jacobian_conjugate!(G::AbstractLieGroup, J, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis())

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -4,7 +4,7 @@
 @doc """
     AbstractGroupOperation
 
-Represent a type of group operation for a [`LieGroup`](@ref) ``$(_math(:G))``, that is a
+Represent a type of group operation for a [`AbstractLieGroup`](@ref) ``$(_math(:G))``, that is a
 smooth binary operation ``$(_math(:∘)) : $(_math(:G)) × $(_math(:G)) → $(_math(:G))``
 on elements of a Lie group ``$(_math(:G))``.
 """
@@ -17,11 +17,11 @@ Specify an orthogonal basis for a Lie algebra.
 This is used as the default within [`hat`](@ref) and [`vee`](@ref).
 
 If not specifically overwritten/implemented for a Lie group, the [`DefaultOrthogonalBasis`](@extref `ManifoldsBase.DefaultOrthogonalBasis`)
-at the [`identity_element`](@ref) on the [`base_manifold](@ref base_manifold(::LieGroup)) acts as a fallback.
+at the [`identity_element`](@ref) on the [`base_manifold](@ref base_manifold(::AbstractLieGroup)) acts as a fallback.
 
 !!! note
     In order to implement the corresponding [`get_coordinates`](@ref) and [`get_vector`](@ref) functions,
-    define `get_coordinates_lie(::LieGroup, p, X, B)` and `get_vector_lie(::LieGroup, p, X, B)`, resp.
+    define `get_coordinates_lie(::AbstractLieGroup, p, X, B)` and `get_vector_lie(::AbstractLieGroup, p, X, B)`, resp.
 """
 struct DefaultLieAlgebraOrthogonalBasis{𝔽} <:
        ManifoldsBase.AbstractOrthogonalBasis{𝔽,ManifoldsBase.TangentSpaceType} end
@@ -30,7 +30,16 @@ function DefaultLieAlgebraOrthogonalBasis(𝔽::ManifoldsBase.AbstractNumbers=�
 end
 
 """
-    LieGroup{𝔽, O<:AbstractGroupOperation, M<:AbstractManifold{𝔽}} <: AbstractManifold{𝔽}
+    AbstractLieGroup{𝔽, O<:AbstractGroupOperation, M<:AbstractManifold{𝔽}} <: AbstractManifold{𝔽}
+
+An abstract type to represent Lie groups. For most cases it should suffice to “combine”
+an $(_link(:AbstractManifold)) with an [`AbstractGroupOperation`](@ref), see [`LieGroup`](@ref).
+"""
+abstract type AbstractLieGroup{𝔽, O<:AbstractGroupOperation, M<:AbstractManifold{𝔽}} <: AbstractManifold{𝔽} end
+
+
+"""
+    LieGroup{𝔽, O<:AbstractGroupOperation, M<:AbstractManifold{𝔽}} <:  AbstractLieGroup{𝔽, O, M}
 
 Represent a Lie Group ``$(_math(:G))``.
 
@@ -53,7 +62,7 @@ Lie groups are named after the Norwegian mathematician [Marius Sophus Lie](https
 Generate a Lie group based on a manifold `M` and a group operation `op`, where vectors by default are stored in the Lie Algebra.
 """
 struct LieGroup{𝔽,O<:AbstractGroupOperation,M<:ManifoldsBase.AbstractManifold{𝔽}} <:
-       ManifoldsBase.AbstractManifold{𝔽}
+       AbstractLieGroup{𝔽,O,M}
     manifold::M
     op::O
 end
@@ -61,7 +70,7 @@ end
 @doc """
     Identity{O<:AbstractGroupOperation}
 
-Represent the group identity element ``e ∈ $(_math(:G))`` on a [`LieGroup`](@ref) ``$(_math(:G))``
+Represent the group identity element ``e ∈ $(_math(:G))`` on an [`AbstractLieGroup`](@ref) ``$(_math(:G))``
 with [`AbstractGroupOperation`](@ref) of type `O`.
 
 Similar to the philosophy that points are agnostic of their group at hand, the identity
@@ -71,7 +80,7 @@ See also [`identity_element`](@ref) on how to obtain the corresponding [`Abstrac
 
 # Constructors
 
-    Identity(::LieGroup{𝔽,O}) where {𝔽,O<:AbstractGroupOperation}
+    Identity(::AbstractLieGroup{𝔽,O}) where {𝔽,O<:AbstractGroupOperation}
     Identity(o::AbstractGroupOperation)
     Identity(::Type{AbstractGroupOperation})
 
@@ -79,14 +88,14 @@ create the identity of the corresponding subtype `O<:`[`AbstractGroupOperation`]
 """
 struct Identity{O<:AbstractGroupOperation} end
 
-Identity(::LieGroup{𝔽,O}) where {𝔽,O<:AbstractGroupOperation} = Identity{O}()
+Identity(::AbstractLieGroup{𝔽,O}) where {𝔽,O<:AbstractGroupOperation} = Identity{O}()
 Identity(::O) where {O<:AbstractGroupOperation} = Identity(O)
 Identity(::Type{O}) where {O<:AbstractGroupOperation} = Identity{O}()
 
 """
     AbstractLieGroupPoint <: ManifoldsBase.AbstractManifoldPoint end
 
-An abstract type for a point on a [`LieGroup`](@ref).
+An abstract type for a point on an [`AbstractLieGroup`](@ref).
 While an points and tangent vectors are usually kept untyped for flexibility,
 it might be necessary to distinguish different types of points, for example
 
@@ -120,8 +129,8 @@ abstract type AbstractLieAlgebraTangentVector <: ManifoldsBase.AbstractTangentVe
 # --- Functions ---
 
 _doc_adjoint = """
-    adjoint(G::LieGroup, g, X)
-    adjoint!(G::LieGroup, Y, g, X)
+    adjoint(G::AbstractLieGroup, g, X)
+    adjoint!(G::AbstractLieGroup, Y, g, X)
 
 Compute the adjoint ``$(_math(:Ad))(g): $(_math(:𝔤)) → $(_math(:𝔤))``, which is defined as
 the differential [`diff_conjugate`](@ref) of the [`conjugate`](@ref) ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1}``
@@ -138,33 +147,34 @@ On matrix Lie groups the adjoint reads ``$(_math(:Ad))(g)[X] = g$(_math(:∘))X$
 """
 
 @doc "$(_doc_adjoint)"
-function Base.adjoint(G::LieGroup, g, X)
+function Base.adjoint(G::AbstractLieGroup, g, X)
     Y = ManifoldsBase.allocate_result(G, adjoint, g, X)
     return adjoint!(G, Y, g, X)
 end
 
 function adjoint! end
 @doc "$(_doc_adjoint)"
-function adjoint!(G::LieGroup, Y, g, X)
+function adjoint!(G::AbstractLieGroup, Y, g, X)
     diff_conjugate!(G, Y, g, Identity(G), X)
     return Y
 end
 
 @doc """
-    base_manifold(G::LieGroup)
+    base_manifold(G::AbstractLieGroup)
 
-Return the manifold stored within the [`LieGroup`](@ref) `G`.
+Return the manifold stored within the [`AbstractLieGroup`](@ref) `G`.
 """
+Manifolds.base_manifold(G::AbstractLieGroup)
 Manifolds.base_manifold(G::LieGroup) = G.manifold
 
 # Since we dispatch per point here, identity is already checked on the `is_point` level.
 function ManifoldsBase.check_point(
-    G::LieGroup{𝔽,O}, g; kwargs...
+    G::AbstractLieGroup{𝔽,O}, g; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return ManifoldsBase.check_point(base_manifold(G), g; kwargs...)
 end
 
-function ManifoldsBase.check_vector(G::LieGroup, g::P, X; kwargs...) where {P}
+function ManifoldsBase.check_vector(G::AbstractLieGroup, g::P, X; kwargs...) where {P}
     return ManifoldsBase.check_vector(
         base_manifold(G), identity_element(G, P), X; kwargs...
     )
@@ -172,11 +182,11 @@ end
 
 # compose g ∘ h
 _doc_compose = """
-    compose(G::LieGroup, g, h)
-    compose!(G::LieGroup, k, g, h)
+    compose(G::AbstractLieGroup, g, h)
+    compose!(G::AbstractLieGroup, k, g, h)
 
 Perform the group operation ``g $(_math(:∘)) h`` for two ``g, h ∈ $(_math(:G))``
-on the [`LieGroup`](@ref) `G`. This can also be done in-place of `h`.
+on the [`AbstractLieGroup`](@ref) `G`. This can also be done in-place of `h`.
 
 !!! info
     This function also handles the case where `g` or/and `h` are the [`Identity`](@ref)`(G)`.
@@ -185,16 +195,16 @@ on the [`LieGroup`](@ref) `G`. This can also be done in-place of `h`.
     group operations on (non-[`Identity`](@ref)` but maybe its numerical representation) elements.
 """
 @doc "$(_doc_compose)"
-compose(G::LieGroup, g, h) = _compose(G, g, h)
-compose(::LieGroup{𝔽,O}, g::Identity{O}, h) where {𝔽,O<:AbstractGroupOperation} = h
-compose(::LieGroup{𝔽,O}, g, h::Identity{O}) where {𝔽,O<:AbstractGroupOperation} = g
+compose(G::AbstractLieGroup, g, h) = _compose(G, g, h)
+compose(::AbstractLieGroup{𝔽,O}, g::Identity{O}, h) where {𝔽,O<:AbstractGroupOperation} = h
+compose(::AbstractLieGroup{𝔽,O}, g, h::Identity{O}) where {𝔽,O<:AbstractGroupOperation} = g
 function compose(
-    ::LieGroup{𝔽,O}, g::Identity{O}, h::Identity{O}
+    ::AbstractLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation}
     return g
 end
 
-function _compose(G::LieGroup, g, h)
+function _compose(G::AbstractLieGroup, g, h)
     k = ManifoldsBase.allocate_result(G, compose, g, h)
     return _compose!(G, k, g, h)
 end
@@ -202,20 +212,20 @@ end
 function compose! end
 
 @doc "$(_doc_compose)"
-compose!(G::LieGroup, k, g, h) = _compose!(G, k, g, h)
-function compose!(G::LieGroup{𝔽,O}, k, ::Identity{O}, h) where {𝔽,O<:AbstractGroupOperation}
+compose!(G::AbstractLieGroup, k, g, h) = _compose!(G, k, g, h)
+function compose!(G::AbstractLieGroup{𝔽,O}, k, ::Identity{O}, h) where {𝔽,O<:AbstractGroupOperation}
     return copyto!(G, k, h)
 end
-function compose!(G::LieGroup{𝔽,O}, k, g, ::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
+function compose!(G::AbstractLieGroup{𝔽,O}, k, g, ::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
     return copyto!(G, k, g)
 end
 function compose!(
-    G::LieGroup{𝔽,O}, k, ::Identity{O}, ::Identity{O}
+    G::AbstractLieGroup{𝔽,O}, k, ::Identity{O}, ::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation}
     return identity_element!(G, k)
 end
 function compose!(
-    ::LieGroup{𝔽,O}, k::Identity{O}, ::Identity{O}, ::Identity{O}
+    ::AbstractLieGroup{𝔽,O}, k::Identity{O}, ::Identity{O}, ::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation}
     return k
 end
@@ -223,40 +233,40 @@ end
 function _compose! end
 
 _doc_conjugate = """
-    conjugate(G::LieGroup, g, h)
-    conjugate!(G::LieGroup, k, g, h)
+    conjugate(G::AbstractLieGroup, g, h)
+    conjugate!(G::AbstractLieGroup, k, g, h)
 
 Compute the conjugation map ``c_g: $(_math(:G)) → $(_math(:G))`` given by ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1}``.
 This can be done in-place of `k`.
 """
 @doc "$(_doc_conjugate)"
-function conjugate(G::LieGroup, g, h)
+function conjugate(G::AbstractLieGroup, g, h)
     k = ManifoldsBase.allocate_result(G, conjugate, h, g)
     return conjugate!(G, k, g, h)
 end
 
 function conjugate! end
 @doc "$(_doc_conjugate)"
-function conjugate!(G::LieGroup, k, g, h)
+function conjugate!(G::AbstractLieGroup, k, g, h)
     inv!(G, k, g) # g^{-1} in-place of k
     compose!(G, k, h, k) # `h∘k` in-place of k
     compose!(G, k, g, k) # `g∘k` in-place of k
     return k
 end
 
-ManifoldsBase.copyto!(G::LieGroup, h, g) = copyto!(base_manifold(G), h, g)
+ManifoldsBase.copyto!(G::AbstractLieGroup, h, g) = copyto!(base_manifold(G), h, g)
 function ManifoldsBase.copyto!(
-    G::LieGroup{𝔽,O}, h::P, g::Identity{O}
+    G::AbstractLieGroup{𝔽,O}, h::P, ::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation,P}
     return ManifoldsBase.copyto!(base_manifold(G), h, identity_element(G, P))
 end
 function ManifoldsBase.copyto!(
-    ::LieGroup{𝔽,O}, h::Identity{O}, ::Identity{O}
+    ::AbstractLieGroup{𝔽,O}, h::Identity{O}, ::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation}
     return h
 end
 function ManifoldsBase.copyto!(
-    G::LieGroup{𝔽,O}, h::Identity{O}, g
+    G::AbstractLieGroup{𝔽,O}, h::Identity{O}, g
 ) where {𝔽,O<:AbstractGroupOperation}
     (is_identity(G, g)) && return h
     throw(
@@ -267,29 +277,29 @@ function ManifoldsBase.copyto!(
     )
 end
 _doc_diff_conjugate = """
-    diff_conjugate(G::LieGroup, g, h, X)
-    diff_conjugate!(G::LieGroup, Y, g, h, X)
+    diff_conjugate(G::AbstractLieGroup, g, h, X)
+    diff_conjugate!(G::AbstractLieGroup, Y, g, h, X)
 
-Compute the differential of the [`conjugate`](@ref) ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1}``,
-which can be performed in-place of `Y`.
+Compute the differential of the [`conjugate`](@ref) ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1}``
+on the [`AbstractLieGroup`](@ref) `G`. The operation can be performed in-place of `Y`.
 
 ```math
   D(c_g(h))[X], $(_tex(:qquad)) X ∈ $(_math(:𝔤)).
 ```
 """
 @doc "$(_doc_diff_conjugate)"
-function diff_conjugate(G::LieGroup, g, h, X)
+function diff_conjugate(G::AbstractLieGroup, g, h, X)
     Y = ManifoldsBase.allocate_result(G, diff_conjugate, g, h, X)
     return diff_conjugate!(G, Y, g, h, X)
 end
 
 function diff_conjugate! end
 @doc "$(_doc_diff_conjugate)"
-diff_conjugate!(::LieGroup, Y, g, h, X)
+diff_conjugate!(::AbstractLieGroup, Y, g, h, X)
 
 _doc_diff_inv = """
-    diff_inv(G::LieGroup, g, X)
-    diff_inv!(G::LieGroup, Y, g, X)
+    diff_inv(G::AbstractLieGroup, g, X)
+    diff_inv!(G::AbstractLieGroup, Y, g, X)
 
 Compute the differential of the function ``ι_{$(_math(:G))}(g) = g^{-1}``, where
 ``Dι_{$(_math(:G))}(g): $(_math(:𝔤)) → $(_math(:𝔤))``.
@@ -297,54 +307,54 @@ This can be done in-place of `Y`.
 """
 
 @doc "$_doc_diff_inv"
-function diff_inv(G::LieGroup, g, X)
+function diff_inv(G::AbstractLieGroup, g, X)
     Y = allocate_result(G, diff_inv, g, X)
     return diff_inv!(G, Y, g, X)
 end
 
 function diff_inv! end
 @doc "$_doc_diff_inv"
-diff_inv!(G::LieGroup, Y, g, X)
+diff_inv!(G::AbstractLieGroup, Y, g, X)
 
 _doc_diff_left_compose = """
-    diff_left_compose(G::LieGroup, g, h, X)
-    diff_left_compose!(G::LieGroup, Y, g, h, X)
+    diff_left_compose(G::AbstractLieGroup, g, h, X)
+    diff_left_compose!(G::AbstractLieGroup, Y, g, h, X)
 
 Compute the differential of the left group multiplication ``λ_g(h) = g$(_math(:∘))h``,
-on the [`LieGroup`](@ref) `G`, that is Compute ``Dλ_g(h)[X]``, ``X ∈ 𝔤``.
+on the [`AbstractLieGroup`](@ref) `G`, that is Compute ``Dλ_g(h)[X]``, ``X ∈ 𝔤``.
 This can be done in-place of `Y`.
 """
 @doc "$(_doc_diff_left_compose)"
-function diff_left_compose(G::LieGroup, g, h, X)
+function diff_left_compose(G::AbstractLieGroup, g, h, X)
     Y = ManifoldsBase.allocate_result(G, diff_left_compose, g, h, X)
     return diff_left_compose!(G, Y, g, h, X)
 end
 
 function diff_left_compose! end
 @doc "$(_doc_diff_left_compose)"
-diff_left_compose!(::LieGroup, Y, g, h, X)
+diff_left_compose!(::AbstractLieGroup, Y, g, h, X)
 
 _doc_diff_right_compose = """
-    diff_right_compose(G::LieGroup, h, g, X)
-    diff_right_compose!(G::LieGroup, Y, h, g, X)
+    diff_right_compose(G::AbstractLieGroup, h, g, X)
+    diff_right_compose!(G::AbstractLieGroup, Y, h, g, X)
 
 Compute the differential of the right group multiplication ``ρ_g(h) = h$(_math(:∘))g``,
-on the [`LieGroup`](@ref) `G`, that is Compute ``Dρ_g(h)[X]``, ``X ∈ 𝔤``
+on the [`AbstractLieGroup`](@ref) `G`, that is Compute ``Dρ_g(h)[X]``, ``X ∈ 𝔤``
 This can be done in-place of `Y`.
 """
 @doc "$(_doc_diff_right_compose)"
-function diff_right_compose(G::LieGroup, h, g, X)
+function diff_right_compose(G::AbstractLieGroup, h, g, X)
     Y = ManifoldsBase.allocate_result(G, diff_right_compose, h, g, X)
     return diff_right_compose!(G, Y, h, g, X)
 end
 
 function diff_right_compose! end
 @doc "$(_doc_diff_right_compose)"
-diff_right_compose!(::LieGroup, Y, g, h, X)
+diff_right_compose!(::AbstractLieGroup, Y, g, h, X)
 
 _doc_exp = """
-    exp(G::LieGroup, g, X)
-    exp!(G::LieGroup, h, g, X)
+    exp(G::AbstractLieGroup, g, X)
+    exp!(G::AbstractLieGroup, h, g, X)
 
 Compute the Lie group exponential map for ``g∈$(_math(:G))`` and ``X∈$(_math(:𝔤))``,
 where ``$(_math(:𝔤))`` denotes the [`LieAlgebra`](@ref) of ``$(_math(:G))``.
@@ -355,9 +365,9 @@ $(_tex(:exp))_g X = g$(_math(:∘))$(_tex(:exp))_{$(_math(:G))}(X)
 ```
 
 where `X` can be scaled by `t`, the computation can be performed in-place of `h`,
-and ``$(_tex(:exp))_{$(_math(:G))}`` denotes the  [Lie group exponential function](@ref exp(::LieGroup, ::Identity, :Any)).
+and ``$(_tex(:exp))_{$(_math(:G))}`` denotes the  [Lie group exponential function](@ref exp(::AbstractLieGroup, ::Identity, :Any)).
 
-If `g` is the [`Identity`](@ref) the [Lie group exponential function](@ref exp(::LieGroup, ::Identity, :Any)) ``$(_tex(:exp))_{$(_math(:G))}`` is computed directly.
+If `g` is the [`Identity`](@ref) the [Lie group exponential function](@ref exp(::AbstractLieGroup, ::Identity, :Any)) ``$(_tex(:exp))_{$(_math(:G))}`` is computed directly.
 Implementing the Lie group exponential function introduces a default implementation with the formula above.
 
 !!! note
@@ -367,18 +377,18 @@ Implementing the Lie group exponential function introduces a default implementat
 """
 
 @doc "$_doc_exp"
-ManifoldsBase.exp(G::LieGroup, ::Any, ::Any)
+ManifoldsBase.exp(G::AbstractLieGroup, ::Any, ::Any)
 
 @doc "$_doc_exp"
-function ManifoldsBase.exp!(G::LieGroup, h, g, X)
+function ManifoldsBase.exp!(G::AbstractLieGroup, h, g, X)
     exp!(G, h, X)
     compose!(G, h, g, h)
     return h
 end
 
 _doc_exponential = """
-    exp(G::LieGroup, X::T)
-    exp!(G::LieGroup, g, X)
+    exp(G::AbstractLieGroup, X::T)
+    exp!(G::AbstractLieGroup, g, X)
 
     Compute the (Lie group) exponential function
 
@@ -407,21 +417,21 @@ The computation can be performed in-place of `g`.
 """
 
 @doc "$(_doc_exponential)"
-function ManifoldsBase.exp(G::LieGroup, X)
+function ManifoldsBase.exp(G::AbstractLieGroup, X)
     g = allocate_result(G, exp, X)
     exp!(G, g, X)
     return g
 end
 
 @doc "$(_doc_exponential)"
-ManifoldsBase.exp!(G::LieGroup, ::Any, ::Any)
+ManifoldsBase.exp!(G::AbstractLieGroup, ::Any, ::Any)
 
 _doc_identity_element = """
-    identity_element(G::LieGroup)
-    identity_element(G::LieGroup, T)
-    identity_element!(G::LieGroup, e::T)
+    identity_element(G::AbstractLieGroup)
+    identity_element(G::AbstractLieGroup, T)
+    identity_element!(G::AbstractLieGroup, e::T)
 
-Return a point representation of the [`Identity`](@ref) on the [`LieGroup`](@ref) `G`.
+Return a point representation of the [`Identity`](@ref) on the [`AbstractLieGroup`](@ref) `G`.
 By default this representation is the default array or number representation.
 If there exist several representations, the type `T` can be used to distinguish between them,
 and it should be provided for both the [`AbstractLieGroupPoint`](@ref) as well as the [`AbstractLieAlgebraTangentVector`](@ref)
@@ -432,87 +442,87 @@ This can be performed in-place of `e`.
 """
 # `function identity_element end`
 @doc "$(_doc_identity_element)"
-function identity_element(G::LieGroup)
+function identity_element(G::AbstractLieGroup)
     e = ManifoldsBase.allocate_result(G, identity_element)
     return identity_element!(G, e)
 end
-function identity_element(G::LieGroup, ::Type)
+function identity_element(G::AbstractLieGroup, ::Type)
     # default, call the other one as well
     return identity_element(G)
 end
 
 function identity_element! end
 @doc "$(_doc_identity_element)"
-identity_element!(G::LieGroup, e)
+identity_element!(G::AbstractLieGroup, e)
 
 _doc_inv = """
-    inv(G::LieGroup, g)
-    inv!(G::LieGroup, h, g)
+    inv(G::AbstractLieGroup, g)
+    inv!(G::AbstractLieGroup, h, g)
 
 Compute the inverse group element ``g^{-1}`` with respect to the [`AbstractGroupOperation`](@ref) ``$(_math(:∘))``
-on the [`LieGroup`](@ref) ``$(_math(:G))``,
+on the [`AbstractLieGroup`](@ref) ``$(_math(:G))``,
 that is, return the unique element ``h=g^{-1}`` such that ``h$(_math(:∘))g=$(_math(:e))``, where ``$(_math(:e))`` denotes the [`Identity`](@ref).
 
 This can be done in-place of `h`, without side effects, that is you can do `inv!(G, g, g)`.
 """
 
 @doc "$_doc_inv"
-function Base.inv(G::LieGroup, g)
+function Base.inv(G::AbstractLieGroup, g)
     h = allocate_result(G, inv, g)
     return inv!(G, h, g)
 end
 
 function inv! end
 @doc "$_doc_inv"
-inv!(G::LieGroup, h, g)
+inv!(G::AbstractLieGroup, h, g)
 
-function Base.inv(::LieGroup{𝔽,O}, e::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
+function Base.inv(::AbstractLieGroup{𝔽,O}, e::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
     return e
 end
 
-function inv!(G::LieGroup{𝔽,O}, g, ::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
+function inv!(G::AbstractLieGroup{𝔽,O}, g, ::Identity{O}) where {𝔽,O<:AbstractGroupOperation}
     return identity_element!(G, g)
 end
 
 _doc_inv_left_compose = """
-    inv_left_compose(G::LieGroup, g, h)
-    inv_left_compose!(G::LieGroup, k, g, h)
+    inv_left_compose(G::AbstractLieGroup, g, h)
+    inv_left_compose!(G::AbstractLieGroup, k, g, h)
 
 Compute the inverse of the left group operation ``λ_g(h) = g$(_math(:∘))h``,
-on the [`LieGroup`](@ref) `G`, that is, compute ``λ_g^{-1}(h) = g^{-1}$(_math(:∘))h``.
+on the [`AbstractLieGroup`](@ref) `G`, that is, compute ``λ_g^{-1}(h) = g^{-1}$(_math(:∘))h``.
 This can be done in-place of `k`.
 """
 @doc "$(_doc_inv_left_compose)"
-function inv_left_compose(G::LieGroup, g, h)
+function inv_left_compose(G::AbstractLieGroup, g, h)
     k = ManifoldsBase.allocate_result(G, inv_left_compose, g, h)
     return inv_left_compose!(G, k, g, h)
 end
 
 function inv_left_compose! end
 @doc "$(_doc_compose)"
-function inv_left_compose!(G::LieGroup, k, g, h)
+function inv_left_compose!(G::AbstractLieGroup, k, g, h)
     inv!(G, k, g) # g^{-1} in-place of k
     compose!(G, k, k, h) # compose `k∘h` in-place of k
     return k
 end
 
 _doc_inv_right_compose = """
-    inv_right_compose(G::LieGroup, h, g)
-    inv_right_compose!(G::LieGroup, k, h, g)
+    inv_right_compose(G::AbstractLieGroup, h, g)
+    inv_right_compose!(G::AbstractLieGroup, k, h, g)
 
 Compute the inverse of the right group operation ``ρ_g(h) = h$(_math(:∘))g``,
-on the [`LieGroup`](@ref) `G`, that is compute ``ρ_g^{-1}(h) = h$(_math(:∘))g^{-1}``.
+on the [`AbstractLieGroup`](@ref) `G`, that is compute ``ρ_g^{-1}(h) = h$(_math(:∘))g^{-1}``.
 This can be done in-place of `k`.
 """
 @doc "$(_doc_inv_right_compose)"
-function inv_right_compose(G::LieGroup, h, g)
+function inv_right_compose(G::AbstractLieGroup, h, g)
     k = ManifoldsBase.allocate_result(G, inv_right_compose, h, g)
     return inv_right_compose!(G, k, h, g)
 end
 
 function inv_right_compose! end
 @doc "$(_doc_inv_right_compose)"
-function inv_right_compose!(G::LieGroup, k, h, g)
+function inv_right_compose!(G::AbstractLieGroup, k, h, g)
     inv!(G, k, g) # g^{-1} in-place of k
     compose!(G, k, h, k) # compose `h∘k` in-place of k
     return k
@@ -520,9 +530,9 @@ end
 
 function is_identity end
 @doc """
-    is_identity(G::LieGroup, q; kwargs...)
+    is_identity(G::AbstractLieGroup, q; kwargs...)
 
-Check whether `q` is the identity on the [`LieGroup`](@ref) ``$(_math(:G))``.
+Check whether `q` is the identity on the [`AbstractLieGroup`](@ref) ``$(_math(:G))``.
 This means it is either the [`Identity`](@ref)`{O}` with the respect to the corresponding
 [`AbstractGroupOperation`](@ref) `O`, or (approximately) the correct point representation.
 
@@ -530,23 +540,23 @@ This means it is either the [`Identity`](@ref)`{O}` with the respect to the corr
 
 [`identity_element`](@ref), [`identity_element!`](@ref)
 """
-is_identity(G::LieGroup, q)
+is_identity(G::AbstractLieGroup, q)
 
 # Declare as “fallback” for types
 
 function is_identity(
-    G::LieGroup{𝔽,O}, h::P; kwargs...
+    G::AbstractLieGroup{𝔽,O}, h::P; kwargs...
 ) where {𝔽,P,O<:AbstractGroupOperation}
     return ManifoldsBase.isapprox(G, identity_element(G, P), h; kwargs...)
 end
 function is_identity(
-    ::LieGroup{𝔽,O}, ::Identity{O}; kwargs...
+    ::AbstractLieGroup{𝔽,O}, ::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return true
 end
 # any other identity than the fitting one
 function is_identity(
-    G::LieGroup{𝔽,<:AbstractGroupOperation},
+    G::AbstractLieGroup{𝔽,<:AbstractGroupOperation},
     h::Identity{<:AbstractGroupOperation};
     kwargs...,
 ) where {𝔽}
@@ -554,23 +564,23 @@ function is_identity(
 end
 
 """
-    is_point(G::LieGroup, g; kwargs...)
+    is_point(G::AbstractLieGroup, g; kwargs...)
 
 Check whether `g` is a valid point on the Lie Group `G`.
 This falls back to checking whether `g` is a valid point on the [`base_manifold`](@ref)`G`.
 unless `g` is an [`Identity`](@ref). Then, it is checked whether it is the
 identity element corresponding to `G`.
 """
-ManifoldsBase.is_point(G::LieGroup, g; kwargs...)
+ManifoldsBase.is_point(G::AbstractLieGroup, g; kwargs...)
 
 # resolve identity already here, everything else passes down to checks.
 
 function ManifoldsBase.is_point(
-    G::LieGroup{𝔽,O}, e::Identity{O}; kwargs...
+    G::AbstractLieGroup{𝔽,O}, e::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return true
 end
-function ManifoldsBase.is_point(G::LieGroup, e::Identity; error::Symbol=:none, kwargs...)
+function ManifoldsBase.is_point(G::AbstractLieGroup, e::Identity; error::Symbol=:none, kwargs...)
     s = """
         The provided point $e is not the Identity on $G.
         Expected an Identity corresponding to $(G.op).
@@ -582,46 +592,46 @@ function ManifoldsBase.is_point(G::LieGroup, e::Identity; error::Symbol=:none, k
 end
 
 function ManifoldsBase.is_vector(
-    G::LieGroup{𝔽,O}, ::Identity{O}, X; kwargs...
+    G::AbstractLieGroup{𝔽,O}, ::Identity{O}, X; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return ManifoldsBase.is_point(LieAlgebra(G), X; kwargs...)
 end
 
 """
-    isapprox(M::LieGroup, g, h; kwargs...)
+    isapprox(M::AbstractLieGroup, g, h; kwargs...)
 
-Check if points `g` and `h` from [`LieGroup`](@ref) are approximately equal.
+Check if points `g` and `h` from [`AbstractLieGroup`](@ref) are approximately equal.
 this function calls the corresponding $(_link(:isapprox)) on the $(_link(:AbstractManifold))
 after handling the cases where one or more
 of the points are the [`Identity`](@ref).
 All keyword argments are passed to this function as well.
 """
-ManifoldsBase.isapprox(G::LieGroup, g, h; kwargs...) =
+ManifoldsBase.isapprox(G::AbstractLieGroup, g, h; kwargs...) =
     isapprox(base_manifold(G), g, h; kwargs...)
 function ManifoldsBase.isapprox(
-    G::LieGroup{𝔽,O}, g::Identity{O}, h; kwargs...
+    G::AbstractLieGroup{𝔽,O}, g::Identity{O}, h; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return ManifoldsBase.isapprox(G, identity_element(G, typeof(h)), h; kwargs...)
 end
 function ManifoldsBase.isapprox(
-    G::LieGroup{𝔽,O}, g, h::Identity{O}; kwargs...
+    G::AbstractLieGroup{𝔽,O}, g, h::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return ManifoldsBase.isapprox(G, g, identity_element(G, typeof(g)); kwargs...)
 end
 function ManifoldsBase.isapprox(
-    G::LieGroup{𝔽,O}, g::Identity{O}, h::Identity{O}; kwargs...
+    G::AbstractLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     return true
 end
 function ManifoldsBase.isapprox(
-    G::LieGroup{𝔽,O}, g::Identity{O}, h::Identity{O2}; kwargs...
+    G::AbstractLieGroup{𝔽,O}, g::Identity{O}, h::Identity{O2}; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation,O2<:AbstractGroupOperation}
     return false
 end
 
 _doc_jacobian_conjugate = """
-    jacobian_conjugate(G::LieGroup, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis())
-    jacobian_conjugate!(G::LieGroup, J, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis())
+    jacobian_conjugate(G::AbstractLieGroup, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis())
+    jacobian_conjugate!(G::AbstractLieGroup, J, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis())
 
 Compute the Jacobian of the [`conjugate`](@ref) ``c_g(h) = g$(_math(:∘))h$(_math(:∘))g^{-1}``,
 with respect to an [`AbstractBasis`](@extref `ManifoldsBase.AbstractBasis`).
@@ -637,7 +647,7 @@ with respect to the given basis.
 """
 @doc "$(_doc_jacobian_conjugate)"
 function jacobian_conjugate(
-    G::LieGroup, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis()
+    G::AbstractLieGroup, g, h, B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis()
 )
     J = ManifoldsBase.allocate_result(G, jacobian_conjugate, g, h, B)
     return jacobian_conjugate!(G, J, g, h, B)
@@ -646,12 +656,12 @@ end
 function jacobian_conjugate! end
 @doc "$(_doc_jacobian_conjugate)"
 jacobian_conjugate!(
-    ::LieGroup, J, g, h; B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis()
+    ::AbstractLieGroup, J, g, h; B::AbstractBasis=DefaultLieAlgebraOrthogonalBasis()
 )
 
 _doc_log = """
-    log(G::LieGroup, g, h)
-    log!(G::LieGroup, X, g, h)
+    log(G::AbstractLieGroup, g, h)
+    log!(G::AbstractLieGroup, X, g, h)
 
 Compute the Lie group logarithmic map ``$(_tex(:log))_g: $(_math(:G)) → $(_math(:𝔤))``,
 where ``$(_math(:𝔤))`` denotes the [`LieAlgebra`](@ref) of ``$(_math(:G))``.
@@ -661,7 +671,7 @@ It is given by
 $(_tex(:log))_g h = $(_tex(:log))_{$(_math(:G))}(g^{-1}$(_math(:∘))h)
 ```
 
-where ``$(_tex(:log))_{$(_math(:G))}`` denotes the [Lie group logarithmic function](@ref log(::LieGroup, :Any))
+where ``$(_tex(:log))_{$(_math(:G))}`` denotes the [Lie group logarithmic function](@ref log(::AbstractLieGroup, :Any))
 The computation can be performed in-place of `X`.
 
 
@@ -673,26 +683,26 @@ The computation can be performed in-place of `X`.
 """
 
 @doc "$_doc_log"
-function ManifoldsBase.log(G::LieGroup, g, h)
+function ManifoldsBase.log(G::AbstractLieGroup, g, h)
     X = allocate_result(G, log, g, h)
     log!(G, X, g, h)
     return X
 end
 
 @doc "$_doc_log"
-function ManifoldsBase.log!(G::LieGroup, X, g, h)
+function ManifoldsBase.log!(G::AbstractLieGroup, X, g, h)
     log!(G, X, compose(G, inv(G, g), h))
     return h
 end
 
 _doc_log = """
-    log(G::LieGroup, g, h)
-    log(G::LieGroup, g)
-    log(G::LieGroup, g::Identity, T)
-    log!(G::LieGroup, X::T, g)
+    log(G::AbstractLieGroup, g, h)
+    log(G::AbstractLieGroup, g)
+    log(G::AbstractLieGroup, g::Identity, T)
+    log!(G::AbstractLieGroup, X::T, g)
 
 Compute the (Lie group) logarithmic function ``$(_tex(:log))_{$(_math(:G))}: $(_math(:G)) → $(_math(:𝔤))``,
-which is the inverse of the [Lie group exponential function](@ref exp(::LieGroup, :Any)).
+which is the inverse of the [Lie group exponential function](@ref exp(::AbstractLieGroup, :Any)).
 For the allocating variant, you can specify the type `T`, when the point argument is the identity and hence does not provide the representation used.
 The computation can be performed in-place of `X::T`, which then determines the type.
 
@@ -705,38 +715,38 @@ The computation can be performed in-place of `X::T`, which then determines the t
 """
 
 @doc "$(_doc_log)"
-function ManifoldsBase.log(G::LieGroup, g)
+function ManifoldsBase.log(G::AbstractLieGroup, g)
     X = allocate_result(G, log, g)
     log!(G, X, g)
     return X
 end
 function ManifoldsBase.log(
-    G::LieGroup{𝔽,Op}, e::Identity{Op}
+    G::AbstractLieGroup{𝔽,Op}, e::Identity{Op}
 ) where {𝔽,Op<:AbstractGroupOperation}
     return zero_vector(LieAlgebra(G))
 end
 function ManifoldsBase.log(
-    G::LieGroup{𝔽,Op}, e::Identity{Op}, T::Type
+    G::AbstractLieGroup{𝔽,Op}, e::Identity{Op}, T::Type
 ) where {𝔽,Op<:AbstractGroupOperation}
     return zero_vector(LieAlgebra(G), T)
 end
 
 @doc "$(_doc_log)"
-ManifoldsBase.log!(G::LieGroup, ::Any, ::Any)
+ManifoldsBase.log!(G::AbstractLieGroup, ::Any, ::Any)
 
 function ManifoldsBase.log!(
     G::L, X, e::Identity{Op}
-) where {𝔽,Op<:AbstractGroupOperation,L<:LieGroup{𝔽,Op}}
+) where {𝔽,Op<:AbstractGroupOperation,L<:AbstractLieGroup{𝔽,Op}}
     return zero_vector!(LieAlgebra(G), X)
 end
 
-ManifoldsBase.manifold_dimension(G::LieGroup) = manifold_dimension(base_manifold(G))
+ManifoldsBase.manifold_dimension(G::AbstractLieGroup) = manifold_dimension(base_manifold(G))
 
 _doc_rand = """
-    rand(::LieGroup; vector_at=nothing, σ::Real=1.0, kwargs...)
-    rand(::LieGroup, PT::Type; vector_at=nothing, σ::Real=1.0, kwargs...)
+    rand(::AbstractLieGroup; vector_at=nothing, σ::Real=1.0, kwargs...)
+    rand(::AbstractLieGroup, PT::Type; vector_at=nothing, σ::Real=1.0, kwargs...)
     rand!(::LieAlgebra, T::Type; σ::Real=1.0, kwargs...)
-    rand!(::LieGroup, gX::PT; vector_at=nothing, σ::Real=1.0, kwargs...)
+    rand!(::AbstractLieGroup, gX::PT; vector_at=nothing, σ::Real=1.0, kwargs...)
     rand!(::LieAlgebra, X::T; σ::Real=1.0, kwargs...)
 
 Compute a random point or tangent vector on a Lie group.
@@ -752,27 +762,27 @@ if you want to generate a random point in a certain representation.
 For the in-place variants the type is inferred from `pX´ and `X`, respectively.
 """
 
-function ManifoldsBase.project!(G::LieGroup, g, p)
+function ManifoldsBase.project!(G::AbstractLieGroup, g, p)
     return ManifoldsBase.project!(base_manifold(G), g, p)
 end
 
 @doc "$(_doc_rand)"
-Random.rand(::LieGroup; kwargs...)
+Random.rand(::AbstractLieGroup; kwargs...)
 
 # New in LIeGroups, maybe move to ManifoldsBase at some point
 @doc "$(_doc_rand)"
-Random.rand(G::LieGroup, T::Type; vector_at=nothing, kwargs...)
+Random.rand(G::AbstractLieGroup, T::Type; vector_at=nothing, kwargs...)
 
-function Random.rand(G::LieGroup, T::Type, d::Integer; kwargs...)
+function Random.rand(G::AbstractLieGroup, T::Type, d::Integer; kwargs...)
     return [rand(G, T; kwargs...) for _ in 1:d]
 end
-function Random.rand(rng::AbstractRNG, G::LieGroup, T::Type, d::Integer; kwargs...)
+function Random.rand(rng::AbstractRNG, G::AbstractLieGroup, T::Type, d::Integer; kwargs...)
     return [rand(rng, G, T; kwargs...) for _ in 1:d]
 end
-function Random.rand(G::LieGroup, d::Integer; kwargs...)
+function Random.rand(G::AbstractLieGroup, d::Integer; kwargs...)
     return [rand(G; kwargs...) for _ in 1:d]
 end
-function Random.rand(G::LieGroup, T::Type; vector_at=nothing, kwargs...)
+function Random.rand(G::AbstractLieGroup, T::Type; vector_at=nothing, kwargs...)
     if vector_at === nothing
         gX = allocate_on(G, T)
     else
@@ -781,7 +791,7 @@ function Random.rand(G::LieGroup, T::Type; vector_at=nothing, kwargs...)
     rand!(G, gX; vector_at=vector_at, kwargs...)
     return gX
 end
-function Random.rand(rng::AbstractRNG, M::LieGroup, T::Type; vector_at=nothing, kwargs...)
+function Random.rand(rng::AbstractRNG, M::AbstractLieGroup, T::Type; vector_at=nothing, kwargs...)
     if vector_at === nothing
         gX = allocate_on(M, T)
     else
@@ -792,12 +802,12 @@ function Random.rand(rng::AbstractRNG, M::LieGroup, T::Type; vector_at=nothing, 
 end
 
 @doc "$(_doc_rand)"
-function Random.rand!(G::LieGroup, pX; kwargs...)
+function Random.rand!(G::AbstractLieGroup, pX; kwargs...)
     return rand!(Random.default_rng(), G, pX; kwargs...)
 end
 
 function Random.rand!(
-    rng::AbstractRNG, G::LieGroup, pX::T; vector_at=nothing, kwargs...
+    rng::AbstractRNG, G::AbstractLieGroup, pX::T; vector_at=nothing, kwargs...
 ) where {T}
     M = base_manifold(G)
     if vector_at === nothing # for points -> pass to manifold
@@ -807,7 +817,7 @@ function Random.rand!(
     end
 end
 
-function ManifoldsBase.representation_size(G::LieGroup)
+function ManifoldsBase.representation_size(G::AbstractLieGroup)
     return representation_size(base_manifold(G))
 end
 
@@ -817,22 +827,22 @@ end
 
 #
 # Allocation hints - mainly pass-through, especially for power manifolds
-function ManifoldsBase.allocate_on(G::LieGroup, T::Type{<:AbstractArray})
+function ManifoldsBase.allocate_on(G::AbstractLieGroup, T::Type{<:AbstractArray})
     return ManifoldsBase.allocate_on(base_manifold(G), T)
 end
 
 function ManifoldsBase.allocate_result(
-    G::LieGroup,
+    G::AbstractLieGroup,
     f::Union{typeof(compose),typeof(inv),typeof(conjugate),typeof(exp)},
     args...,
 )
     return ManifoldsBase.allocate_result(base_manifold(G), ManifoldsBase.exp, args...)
 end
-function ManifoldsBase.allocate_result(G::LieGroup, f::typeof(log), args...)
+function ManifoldsBase.allocate_result(G::AbstractLieGroup, f::typeof(log), args...)
     return ManifoldsBase.allocate_result(base_manifold(G), f, args...)
 end
 function ManifoldsBase.allocate_result(
-    G::LieGroup, f::Union{typeof(rand),typeof(identity_element)}
+    G::AbstractLieGroup, f::Union{typeof(rand),typeof(identity_element)}
 )
     # both get a type allocated like rand
     return ManifoldsBase.allocate_result(base_manifold(G), rand)

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -281,7 +281,7 @@ function test_diff_inv(
         if test_mutating
             Y2 = zero_vector(𝔤, typeof(X))
             Y2 = diff_inv!(G, Y2, g, X)
-            @test isapprox(G, g, Y1, Y2)
+            @test isapprox(𝔤, Y1, Y2)
         end
         if !ismissing(expected)
             @test isapprox(𝔤, Y1, expected)

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -582,7 +582,7 @@ end
 # --- `I`
 
 """
-    test_injectivity_radius(G::LieGroup; kwargs...)
+    test_injectivity_radius(G::AbstractLieGroup; kwargs...)
 
 Test the function `injectivity_radius`.
 
@@ -590,7 +590,7 @@ Test the function `injectivity_radius`.
 
 * `expected=missing`: expected value for global injectivity radius.
 """
-function test_injectivity_radius(G::LieGroup; expected=missing)
+function test_injectivity_radius(G::AbstractLieGroup; expected=missing)
     @testset "injectivity radius" begin
         if ismissing(expected)
             @test injectivity_radius(G) isa Real
@@ -709,7 +709,7 @@ end
 
 Test that the `Identity` returns that `is_identity` is true and that it is a point
 """
-function test_identity(G::LieGroup)
+function test_identity(G::AbstractLieGroup)
     @testset "Identity" begin
         e = Identity(G)
         @test is_point(G, e; error=:error)
@@ -755,7 +755,7 @@ end
 #
 # --- R
 """
-    test_rand(G::LieGroup)
+    test_rand(G::AbstractLieGroup)
 
 Test the random function, both the allocating and the in-place variant,
 as well as the variant with an `rng`, if one is provided.

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -178,7 +178,12 @@ Test  `conjugate`.
 * `test_mutating::Bool=true`: test the mutating functions
 """
 function test_conjugate(
-    G::AbstractLieGroup, g, h; expected=missing, test_default::Bool=true, test_mutating::Bool=true
+    G::AbstractLieGroup,
+    g,
+    h;
+    expected=missing,
+    test_default::Bool=true,
+    test_mutating::Bool=true,
 )
     @testset "conjugate" begin
         k1 = conjugate(G, g, h)
@@ -264,7 +269,9 @@ Test  `diff_inv`.
   only consistency between the allocating and the in-place variant is checked.
 * `test_mutating::Bool=true`: test the mutating functions
 """
-function test_diff_inv(G::AbstractLieGroup, g, X; expected=missing, test_mutating::Bool=true)
+function test_diff_inv(
+    G::AbstractLieGroup, g, X; expected=missing, test_mutating::Bool=true
+)
     @testset "diff_inv" begin
         𝔤 = LieAlgebra(G)
         # Check that at identity it is in the Lie algebra
@@ -665,7 +672,9 @@ and that the double inverse is the identity.
 * `test_mutating::Bool=true`: test the mutating functions
 * `test_identity::Bool=true`: test that `inv(e) == e`
 """
-function test_inv(G::AbstractLieGroup, g; test_mutating::Bool=true, test_identity::Bool=true)
+function test_inv(
+    G::AbstractLieGroup, g; test_mutating::Bool=true, test_identity::Bool=true
+)
     @testset "inv" begin
         k1 = inv(G, g)
         @test is_point(G, k1; error=:error)
@@ -725,7 +734,9 @@ Test  `lie_bracket`.
   if not provided, only consistency between the allocating and the in-place variant is checked.
 * `test_mutating::Bool=true`: test the mutating functions
 """
-function test_lie_bracket(G::AbstractLieGroup, X, Y; expected=missing, test_mutating::Bool=true)
+function test_lie_bracket(
+    G::AbstractLieGroup, X, Y; expected=missing, test_mutating::Bool=true
+)
     @testset "lie_bracket" begin
         𝔤 = LieAlgebra(G)
         Z1 = lie_bracket(𝔤, X, Y)
@@ -757,7 +768,10 @@ both the random point and the random tangent vector variants are tested.
 * `rng=missing`: test with a specific random number generator
 """
 function test_rand(
-    G::AbstractLieGroup, g; test_mutating::Bool=true, rng::Union{Missing,AbstractRNG}=missing
+    G::AbstractLieGroup,
+    g;
+    test_mutating::Bool=true,
+    rng::Union{Missing,AbstractRNG}=missing,
 )
     @testset "rand" begin
         g1 = rand(G)

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -715,9 +715,9 @@ function test_identity(G::AbstractLieGroup)
         @test is_point(G, e; error=:error)
         @test is_identity(G, e)
         e2 = Identity(DummyOperation)
-        @test !is_point(G, e2)
+        @test !is_point(G, e2; error=:none)
         @test_throws DomainError !is_point(G, e2; error=:error)
-        @test !is_identity(G, e2)
+        @test !is_identity(G, e2; error=:none)
     end
     return nothing
 end
@@ -819,7 +819,7 @@ For now this (only) checks that `"\$G"` yields the `repr_string`.
 
 Requires `show` (or `repr`) to be implemented.
 """
-function test_show(G::Union{GroupAction,LieGroup}, repr_string::AbstractString)
+function test_show(G::Union{GroupAction,AbstractLieGroup}, repr_string::AbstractString)
     @testset "repr(G, g, h)" begin
         @test repr(G) == repr_string
     end

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -53,7 +53,7 @@ end
 #
 # --- A
 """
-    test_adjoint(G::LieGroup, g, X; kwargs...)
+    test_adjoint(G::AbstractLieGroup, g, X; kwargs...)
 
 Test  `adjoint` function for a given Lie group element `g` and a Lie Algebra vector `X`
 
@@ -62,7 +62,7 @@ Test  `adjoint` function for a given Lie group element `g` and a Lie Algebra vec
   default from `diff_conjugate` is used
 * `test_mutating::Bool=true`: test the mutating functions
 """
-function test_adjoint(G::LieGroup, g, X; expected=missing, test_mutating::Bool=true)
+function test_adjoint(G::AbstractLieGroup, g, X; expected=missing, test_mutating::Bool=true)
     @testset "adjoint" begin
         v = if ismissing(expected)
             diff_conjugate(G, g, identity_element(G, typeof(X)), X)
@@ -108,7 +108,7 @@ end
 #
 # --- C
 """
-    test_compose(G::LieGroup, g, h; kwargs...)
+    test_compose(G::AbstractLieGroup, g, h; kwargs...)
 
 Test  `compose` for given Lie group elements `g`, `h`.
 
@@ -121,7 +121,7 @@ Test  `compose` for given Lie group elements `g`, `h`.
 * `test_mutating::Bool=true`: test the mutating functions
 """
 function test_compose(
-    G::LieGroup,
+    G::AbstractLieGroup,
     g,
     h;
     atol::Real=0,
@@ -167,7 +167,7 @@ function test_compose(
 end
 
 """
-    test_conjugate(G::LieGroup, g, h; expected=missing)
+    test_conjugate(G::AbstractLieGroup, g, h; expected=missing)
 
 Test  `conjugate`.
 
@@ -178,7 +178,7 @@ Test  `conjugate`.
 * `test_mutating::Bool=true`: test the mutating functions
 """
 function test_conjugate(
-    G::LieGroup, g, h; expected=missing, test_default::Bool=true, test_mutating::Bool=true
+    G::AbstractLieGroup, g, h; expected=missing, test_default::Bool=true, test_mutating::Bool=true
 )
     @testset "conjugate" begin
         k1 = conjugate(G, g, h)
@@ -255,7 +255,7 @@ function test_diff_group_apply(
 end
 
 """
-    test_diff_inv(G::LieGroup, g, X; expected=missing)
+    test_diff_inv(G::AbstractLieGroup, g, X; expected=missing)
 
 Test  `diff_inv`.
 
@@ -264,7 +264,7 @@ Test  `diff_inv`.
   only consistency between the allocating and the in-place variant is checked.
 * `test_mutating::Bool=true`: test the mutating functions
 """
-function test_diff_inv(G::LieGroup, g, X; expected=missing, test_mutating::Bool=true)
+function test_diff_inv(G::AbstractLieGroup, g, X; expected=missing, test_mutating::Bool=true)
     @testset "diff_inv" begin
         𝔤 = LieAlgebra(G)
         # Check that at identity it is in the Lie algebra
@@ -283,7 +283,7 @@ function test_diff_inv(G::LieGroup, g, X; expected=missing, test_mutating::Bool=
 end
 
 """
-    test_diff_left_compose(G::LieGroup, g, h, X; expected=missing)
+    test_diff_left_compose(G::AbstractLieGroup, g, h, X; expected=missing)
 
 Test  `diff_left_compose`.
 
@@ -293,7 +293,7 @@ Test  `diff_left_compose`.
 * `test_mutating::Bool=true`: test the mutating functions
 """
 function test_diff_left_compose(
-    G::LieGroup, g, h, X; expected=missing, test_mutating::Bool=true
+    G::AbstractLieGroup, g, h, X; expected=missing, test_mutating::Bool=true
 )
     @testset "diff_left_compose" begin
         𝔤 = LieAlgebra(G)
@@ -313,7 +313,7 @@ function test_diff_left_compose(
 end
 
 """
-    test_diff_right_compose(G::LieGroup, g, h, X; expected=missing)
+    test_diff_right_compose(G::AbstractLieGroup, g, h, X; expected=missing)
 
 Test  `diff_right_compose`.
 
@@ -323,7 +323,7 @@ Test  `diff_right_compose`.
 * `test_mutating::Bool=true`: test the mutating functions
 """
 function test_diff_right_compose(
-    G::LieGroup, g, h, X; expected=missing, test_mutating::Bool=true
+    G::AbstractLieGroup, g, h, X; expected=missing, test_mutating::Bool=true
 )
     @testset "diff_right_compose" begin
         𝔤 = LieAlgebra(G)
@@ -343,14 +343,14 @@ function test_diff_right_compose(
 end
 
 """
-    test_copyto(G::LieGroup, g)
+    test_copyto(G::AbstractLieGroup, g)
 
 Test that `copyto!` works also when copying over an `Identity`.
 
 The point `g` can be any point _but_ the `identity_element`.
 The group has to be a mutating one, that is, not work on isbit types.
 """
-function test_copyto(G::LieGroup, g)
+function test_copyto(G::AbstractLieGroup, g)
     @testset "copyto!" begin
         k = copy(G, g)
         e = Identity(G)
@@ -381,7 +381,7 @@ end
 Test  `diff_conjugate`
 """
 function test_diff_conjugate(
-    G::LieGroup, g, h, X; expected=missing, test_mutating::Bool=true
+    G::AbstractLieGroup, g, h, X; expected=missing, test_mutating::Bool=true
 )
     𝔤 = LieAlgebra(G)
     @testset "diff_conjugate" begin
@@ -402,7 +402,7 @@ end
 #
 # --- E
 """
-    test_exp_log(G::LieGroup, g, h, X)
+    test_exp_log(G::AbstractLieGroup, g, h, X)
 
 Test  `exp` and `log` for given Lie group elements `g`, `h` and
 a vector `X` from the Lie Algebra.
@@ -418,7 +418,7 @@ a vector `X` from the Lie Algebra.
 * `test_mutating::Bool=true`: test the mutating functions
 """
 function test_exp_log(
-    G::LieGroup,
+    G::AbstractLieGroup,
     g,
     h,
     X;
@@ -511,7 +511,7 @@ end
 #
 # --- H
 """
-    test_hat_vee(G::LieGroup, g, X; kwargs...)
+    test_hat_vee(G::AbstractLieGroup, g, X; kwargs...)
 
 Test `hat` and `vee` for given Lie group element `g` and a Lie Algebra vector `X`.
 
@@ -523,7 +523,7 @@ Test `hat` and `vee` for given Lie group element `g` and a Lie Algebra vector `X
 * `test_hat::Bool=true`: test the hat function
 """
 function test_hat_vee(
-    G::LieGroup,
+    G::AbstractLieGroup,
     g,
     X;
     test_mutating::Bool=true,
@@ -596,7 +596,7 @@ function test_injectivity_radius(G::LieGroup; expected=missing)
 end
 
 """
-    test_inv_compose(G::LieGroup, g, h, X; kwargs...)
+    test_inv_compose(G::AbstractLieGroup, g, h, X; kwargs...)
 
 Test the special functions combining inv and compose, `inv_left_compose` and `inv_right_compose`.
 For these tests both `compose` and `inv` are required.
@@ -608,7 +608,7 @@ For these tests both `compose` and `inv` are required.
 * `test_right::Bool=true`: test ``g∘h^{-1}``
 """
 function test_inv_compose(
-    G::LieGroup,
+    G::AbstractLieGroup,
     g,
     h;
     expected_left=missing,
@@ -655,7 +655,7 @@ function test_inv_compose(
 end
 
 """
-    test_inv(G::LieGroup, g)
+    test_inv(G::AbstractLieGroup, g)
 
 Test the inverse function, both the allocating and the in-place variant,
 and that the double inverse is the identity.
@@ -665,7 +665,7 @@ and that the double inverse is the identity.
 * `test_mutating::Bool=true`: test the mutating functions
 * `test_identity::Bool=true`: test that `inv(e) == e`
 """
-function test_inv(G::LieGroup, g; test_mutating::Bool=true, test_identity::Bool=true)
+function test_inv(G::AbstractLieGroup, g; test_mutating::Bool=true, test_identity::Bool=true)
     @testset "inv" begin
         k1 = inv(G, g)
         @test is_point(G, k1; error=:error)
@@ -696,7 +696,7 @@ function test_inv(G::LieGroup, g; test_mutating::Bool=true, test_identity::Bool=
 end
 
 """
-    test_is_identity(G::LieGroup, g)
+    test_is_identity(G::AbstractLieGroup, g)
 
 Test that the `Identity` returns that `is_identity` is true and that it is a point
 """
@@ -716,7 +716,7 @@ end
 #
 # --- L
 """
-    test_lie_bracket(G::LieGroup, X, Y; expected=missing)
+    test_lie_bracket(G::AbstractLieGroup, X, Y; expected=missing)
 
 Test  `lie_bracket`.
 
@@ -725,7 +725,7 @@ Test  `lie_bracket`.
   if not provided, only consistency between the allocating and the in-place variant is checked.
 * `test_mutating::Bool=true`: test the mutating functions
 """
-function test_lie_bracket(G::LieGroup, X, Y; expected=missing, test_mutating::Bool=true)
+function test_lie_bracket(G::AbstractLieGroup, X, Y; expected=missing, test_mutating::Bool=true)
     @testset "lie_bracket" begin
         𝔤 = LieAlgebra(G)
         Z1 = lie_bracket(𝔤, X, Y)
@@ -757,7 +757,7 @@ both the random point and the random tangent vector variants are tested.
 * `rng=missing`: test with a specific random number generator
 """
 function test_rand(
-    G::LieGroup, g; test_mutating::Bool=true, rng::Union{Missing,AbstractRNG}=missing
+    G::AbstractLieGroup, g; test_mutating::Bool=true, rng::Union{Missing,AbstractRNG}=missing
 )
     @testset "rand" begin
         g1 = rand(G)
@@ -816,7 +816,7 @@ end
 #
 #
 """
-    test_lie_group(G::LieGroup, properties::Dict, expectations::Dict)
+    test_lie_group(G::AbstractLieGroup, properties::Dict, expectations::Dict)
 
 Test the Lie group ``G`` based on a `Dict` of properties and a `Dict` of `expectations
 
@@ -846,7 +846,7 @@ Possible `expectations` are
 * `:repr` is a sting one gets from `repr(G)`
 * `:vee` for the result of `vee(G, X)` where `X` is the first of the vectors
 """
-function test_lie_group(G::LieGroup, properties::Dict, expectations::Dict=Dict())
+function test_lie_group(G::AbstractLieGroup, properties::Dict, expectations::Dict=Dict())
     atol = get(expectations, :atol, 0.0)
     mutating = get(properties, :Mutating, true)
     functions = get(properties, :Functions, Function[])
@@ -1009,7 +1009,7 @@ function test_lie_group(G::LieGroup, properties::Dict, expectations::Dict=Dict()
 end
 
 """
-    test_group_action(G::LieGroup, properties::Dict, expectations::Dict)
+    test_group_action(G::AbstractLieGroup, properties::Dict, expectations::Dict)
 
 Test the Lie group ``G`` based on a `Dict` of properties and a `Dict` of `expectations`.
 
@@ -1030,7 +1030,7 @@ Possible `expectations` are
 * `:apply` for the result of `apply` on the first group and manifold point
 * `:diff_apply` for the result of `apply` on the first group and manifold point together with the first tangent vector
 * `:atol` a global absolute tolerance, defaults to `1e-8`
-* `:group` is the `LieGroup` describing the action
+* `:group` is the `AbstractLieGroup` describing the action
 * `:manifold` is the `AbstractManifold` the action acts upon
 * `:repr` is a sting one gets from `repr(G)`
 """

--- a/test/groups/test_translation_group.jl
+++ b/test/groups/test_translation_group.jl
@@ -17,6 +17,7 @@ begin
             adjoint,
             compose,
             conjugate,
+            diff_conjugate,
             diff_inv,
             diff_left_compose,
             diff_right_compose,

--- a/test/groups/test_validation_group.jl
+++ b/test/groups/test_validation_group.jl
@@ -39,7 +39,7 @@ using LieGroupsTestSuite
         :Functions => fcts,
     )
     expectations = Dict(
-        :repr => "TranslationGroup(3; field=ℝ)",
+        :repr => "ValidationLieGroup of TranslationGroup(3; field=ℝ)\n    * mode = :error\n",
         :diff_inv => -X1,
         :diff_left_compose => X1,
         :diff_right_compose => X1,
@@ -48,14 +48,14 @@ using LieGroupsTestSuite
     test_lie_group(VG, properties, expectations)
 
     properties = Dict(
-        :Name => "ValidationLieGroup of TranslationGroup(3; field=ℝ)\n    * mode = :error",
+        :Name => "Validation of Translation group with types points/vectors",
         :Points => [vg1, vg2, vg3],
         :Vectors => [vX1, vX2, vX3],
         :Rng => Random.MersenneTwister(),
         :Functions => fcts,
     )
     expectations = Dict(
-        :Name => "ValidationLieGroup of TranslationGroup(3; field=ℝ)\n    * mode = :error",
+        :Name => "ValidationLieGroup of TranslationGroup(3; field=ℝ)\n    * mode = :error\n",
         :diff_left_compose => X1,
         :diff_right_compose => X1,
         :lie_bracket => zero(X1),

--- a/test/groups/test_validation_group.jl
+++ b/test/groups/test_validation_group.jl
@@ -4,4 +4,61 @@ s = joinpath(@__DIR__, "..", "LieGroupsTestSuite.jl")
 !(s in LOAD_PATH) && (push!(LOAD_PATH, s))
 using LieGroupsTestSuite
 
-@testset "Validation Lie group" begin end
+@testset "Validation Lie group" begin
+    G = TranslationGroup(3)
+    g1, g2, g3 = [1.0, 0.0, 0.0], [0.0, 3.0, 0.0], [1.1, 1.2, 3.3]
+    X1, X2, X3 = [0.0, 1.0, 0.0], [2.0, 0.0, 0.0], [0.1, 0.2, 0.3]
+    VG = ValidationLieGroup(G)
+    vg1, vg2, vg3 = ValidationMPoint.([g1, g2, g3])
+    vX1, vX2, vX3 = ValidationLieAlgebraTangentVector.([X1, X2, X3])
+    fcts = [
+        adjoint,
+        compose,
+        conjugate,
+        diff_inv,
+        diff_left_compose,
+        diff_right_compose,
+        exp,
+        hat,
+        identity_element,
+        inv,
+        inv_left_compose,
+        inv_right_compose,
+        is_identity,
+        lie_bracket,
+        log,
+        rand,
+        show,
+        vee,
+    ]
+    properties = Dict(
+        :Name => "Validation of Translation group",
+        :Points => [g1, g2, g3],
+        :Vectors => [X1, X2, X3],
+        :Rng => Random.MersenneTwister(),
+        :Functions => fcts,
+    )
+    expectations = Dict(
+        :repr => "TranslationGroup(3; field=ℝ)",
+        :diff_inv => -X1,
+        :diff_left_compose => X1,
+        :diff_right_compose => X1,
+        :lie_bracket => zero(X1),
+    )
+    test_lie_group(VG, properties, expectations)
+
+    properties = Dict(
+        :Name => "ValidationLieGroup of TranslationGroup(3; field=ℝ)\n    * mode = :error",
+        :Points => [vg1, vg2, vg3],
+        :Vectors => [vX1, vX2, vX3],
+        :Rng => Random.MersenneTwister(),
+        :Functions => fcts,
+    )
+    expectations = Dict(
+        :Name => "ValidationLieGroup of TranslationGroup(3; field=ℝ)\n    * mode = :error",
+        :diff_left_compose => X1,
+        :diff_right_compose => X1,
+        :lie_bracket => zero(X1),
+    )
+    test_lie_group(VG, properties, expectations)
+end

--- a/test/groups/test_validation_group.jl
+++ b/test/groups/test_validation_group.jl
@@ -4,5 +4,4 @@ s = joinpath(@__DIR__, "..", "LieGroupsTestSuite.jl")
 !(s in LOAD_PATH) && (push!(LOAD_PATH, s))
 using LieGroupsTestSuite
 
-@testset "Validation Lie group" begin
-end
+@testset "Validation Lie group" begin end

--- a/test/groups/test_validation_group.jl
+++ b/test/groups/test_validation_group.jl
@@ -5,5 +5,4 @@ s = joinpath(@__DIR__, "..", "LieGroupsTestSuite.jl")
 using LieGroupsTestSuite
 
 @testset "Validation Lie group" begin
-
 end

--- a/test/groups/test_validation_group.jl
+++ b/test/groups/test_validation_group.jl
@@ -1,0 +1,9 @@
+using LieGroups, Random, Test
+
+s = joinpath(@__DIR__, "..", "LieGroupsTestSuite.jl")
+!(s in LOAD_PATH) && (push!(LOAD_PATH, s))
+using LieGroupsTestSuite
+
+@testset "Validation Lie group" begin
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ end
         include_test("groups/test_special_euclidean_group.jl")
         include_test("groups/test_special_unitary_group.jl")
         include_test("groups/test_translation_group.jl")
+        include_test("groups/test_validation_group.jl")
     end
     include("test_utils.jl")
     include("test_aqua.jl")


### PR DESCRIPTION
📋

This PR aims to provide the analogue of a [`ValidationManifold`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/manifolds/#A-manifold-for-validation) for Lie groups. Internally one can (but does not have to) add such a validation also for the inner manifold functions.

* [x] implement the Lie groups interface
* [x] 📚 adapt docs
* [x] resolve ambiguties 
* [x] test coverage