### PR TITLE
Towards consistent return types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `is_flat` for `SpecialEuclideanGroup`
 * `inner` and `norm` for `LieAlgebra` to compute the inner product and norm on the Lie algebra.
 
+### Changed
+
+* `identity_element` on `UnitaryGroup(1, ℍ)` now returns by default a 1x1 `Matrix` instead of a number to be consistent with higher-dimensional unitary quaternionic groups. Use `identity_element(UnitaryGroup(1, ℍ), QuaternionF64)` to get a number corresponding to the identity.
+
 ### Fixed
 
 * `get_vector` on `SpecialEuclideanGroup` with `ArrayPartition` point type.
-* `identity_element` and `zero_vector` are now all useing a type as second argument and
+* `identity_element` and `zero_vector` are now all using a type as second argument and
   respect this type more thoroughly.
 
 ## [0.1.1] 2025-05-05

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `get_vector` on `SpecialEuclideanGroup` with `ArrayPartition` point type.
+* `identity_element` and `zero_vector` are now all useing a type as second argument and
+  respect this type more thoroughly.
 
 ## [0.1.1] 2025-05-05
 

--- a/ext/LieGroupsRecursiveArrayToolsExt/LieGroupsRecursiveArrayToolsExt.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/LieGroupsRecursiveArrayToolsExt.jl
@@ -8,4 +8,17 @@ using ManifoldsBase: base_manifold
 
 include("special_euclidean_group_RAT_ext.jl")
 
+function LieGroups.identity_element(
+    G::LieGroup{𝔽,<:LieGroups.AbstractProductGroupOperation}, ::Type{ArrayPartition}
+) where {𝔽}
+    Gs = map(LieGroup, G.manifold.manifolds, G.op.operations)
+    return ArrayPartition(map(identity_element, Gs)...)
+end
+function LieGroups.identity_element(
+    G::LieGroup{𝔽,<:LieGroups.AbstractProductGroupOperation}, ::Type{<:ArrayPartition{T,U}}
+) where {𝔽,T,U<:Tuple}
+    Gs = map(LieGroup, G.manifold.manifolds, G.op.operations)
+    return ArrayPartition(map(identity_element, Gs, U.parameters)...)
+end
+
 end

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -157,6 +157,12 @@ function LieGroups.identity_element(
 ) where {A<:ArrayPartition}
     return SpecialEuclideanProductPoint(identity_element(G, A))
 end
+function LieGroups.identity_element(
+    G::SpecialEuclideanGroup, ::Type{<:SpecialEuclideanProductPoint}
+)
+    return SpecialEuclideanProductPoint(identity_element(G, ArrayPartition))
+end
+
 function LieGroups.identity_element!(G::LieGroups.SpecialEuclideanGroup, g::ArrayPartition)
     SOn, Tn = LieGroups._SOn_and_Tn(G)
     identity_element!(SOn, ManifoldsBase.submanifold_component(G, g, :Rotation))

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -141,6 +141,12 @@ function LieGroups.identity_element(
     return ArrayPartition(identity_element(SOn), identity_element(Tn))
 end
 function LieGroups.identity_element(
+    G::LieGroups.RightSpecialEuclideanGroup, ::Type{ArrayPartition}
+)
+    SOn, Tn = LieGroups._SOn_and_Tn(G)
+    return ArrayPartition(identity_element(Tn), identity_element(SOn))
+end
+function LieGroups.identity_element(
     G::LieGroups.LeftSpecialEuclideanGroup, ::Type{<:ArrayPartition{T,Tuple{A,B}}}
 ) where {T,A,B}
     SOn, Tn = LieGroups._SOn_and_Tn(G)
@@ -157,12 +163,6 @@ function LieGroups.identity_element(
 ) where {A<:ArrayPartition}
     return SpecialEuclideanProductPoint(identity_element(G, A))
 end
-function LieGroups.identity_element(
-    G::SpecialEuclideanGroup, ::Type{<:SpecialEuclideanProductPoint}
-)
-    return SpecialEuclideanProductPoint(identity_element(G, ArrayPartition))
-end
-
 function LieGroups.identity_element!(G::LieGroups.SpecialEuclideanGroup, g::ArrayPartition)
     SOn, Tn = LieGroups._SOn_and_Tn(G)
     identity_element!(SOn, ManifoldsBase.submanifold_component(G, g, :Rotation))

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -135,30 +135,6 @@ function ManifoldsBase.exp!(
 end
 
 function LieGroups.identity_element(
-    G::LieGroups.LeftSpecialEuclideanGroup, ::Type{ArrayPartition}
-)
-    SOn, Tn = LieGroups._SOn_and_Tn(G)
-    return ArrayPartition(identity_element(SOn), identity_element(Tn))
-end
-function LieGroups.identity_element(
-    G::LieGroups.RightSpecialEuclideanGroup, ::Type{ArrayPartition}
-)
-    SOn, Tn = LieGroups._SOn_and_Tn(G)
-    return ArrayPartition(identity_element(Tn), identity_element(SOn))
-end
-function LieGroups.identity_element(
-    G::LieGroups.LeftSpecialEuclideanGroup, ::Type{<:ArrayPartition{T,Tuple{A,B}}}
-) where {T,A,B}
-    SOn, Tn = LieGroups._SOn_and_Tn(G)
-    return ArrayPartition(identity_element(SOn, A), identity_element(Tn, B))
-end
-function LieGroups.identity_element(
-    G::LieGroups.RightSpecialEuclideanGroup, ::Type{<:ArrayPartition{T,Tuple{A,B}}}
-) where {T,A,B}
-    SOn, Tn = LieGroups._SOn_and_Tn(G)
-    return ArrayPartition(identity_element(Tn, A), identity_element(SOn, B))
-end
-function LieGroups.identity_element(
     G::SpecialEuclideanGroup, ::Type{<:SpecialEuclideanProductPoint{A}}
 ) where {A<:ArrayPartition}
     return SpecialEuclideanProductPoint(identity_element(G, A))

--- a/src/Lie_algebra/Lie_algebra_interface.jl
+++ b/src/Lie_algebra/Lie_algebra_interface.jl
@@ -413,7 +413,9 @@ ManifoldsBase.zero_vector(G::LieGroup{𝔽,<:O}, T::Type) where {𝔽,O<:Abstrac
 
 function ManifoldsBase.zero_vector(𝔤::LieAlgebra, T::Type)
     G = base_lie_group(𝔤) # access manifold twice -> pass to manifold directly
-    return ManifoldsBase.zero_vector(base_manifold(G), identity_element(G, T))
+    return ManifoldsBase.zero_vector(
+        base_manifold(G), identity_element(G, point_type(G, T))
+    )
 end
 function ManifoldsBase.zero_vector(𝔤::LieAlgebra)
     G = base_lie_group(𝔤) # access manifold twice -> pass to manifold directly

--- a/src/group_operations/addition_operation.jl
+++ b/src/group_operations/addition_operation.jl
@@ -139,6 +139,11 @@ which for the [`AdditionGroupOperation`](@ref) is the zero element or array.
 identity_element(::LieGroup{𝔽,AdditionGroupOperation}) where {𝔽}
 
 function identity_element(
+    G::LieGroup{𝔽,AdditionGroupOperation}, ::Type{T}
+) where {𝔽,T<:AbstractArray}
+    return zeros(representation_size(G.manifold))
+end
+function identity_element(
     ::LieGroup{𝔽,AdditionGroupOperation}, ::Type{T}
 ) where {𝔽,T<:Union{Number,AbstractArray{<:Number,0}}}
     return zero(T)

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -218,10 +218,10 @@ which for an [`AbstractMultiplicationGroupOperation`](@ref) is the one-element o
 identity_element(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}) where {𝔽}
 
 function identity_element(
-    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Type{T}
-) where {𝔽,T<:AbstractArray}
+    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Type{<:AbstractArray{T,2}}
+) where {𝔽,T}
     (N, M) = representation_size(G.manifold)
-    return Matrix{Float64}(I(N))
+    return Matrix{T}(I(N))
 end
 
 @doc "$(_doc_identity_element_mult)"

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -217,6 +217,13 @@ which for an [`AbstractMultiplicationGroupOperation`](@ref) is the one-element o
 @doc "$(_doc_identity_element_mult)"
 identity_element(::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}) where {𝔽}
 
+function identity_element(
+    G::LieGroup{𝔽,<:AbstractMultiplicationGroupOperation}, ::Type{T}
+) where {𝔽,T<:AbstractArray}
+    (N, M) = representation_size(G.manifold)
+    return Matrix{Float64}(I(N))
+end
+
 @doc "$(_doc_identity_element_mult)"
 identity_element!(::LieGroup{𝔽,<:MatrixMultiplicationGroupOperation}, e) where {𝔽}
 function identity_element!(

--- a/src/group_operations/multiplication_operation_abelian.jl
+++ b/src/group_operations/multiplication_operation_abelian.jl
@@ -113,7 +113,7 @@ Compute the differential of the left group multiplication ``λ_g(h) = g$(_math(:
 
 Due to differences in the representation of some abelian Lie groups, this method wraps a concrete implementation of a specific abelian LieGroup with inputs of type `AbstractArray{<:Any,0}` and supports in-place computation.
 
-This can be computed in-place of `Y` if `Y` is `mutable`.    
+This can be computed in-place of `Y` if `Y` is `mutable`.
 """#
 
 @doc "$(_doc_diff_left_compose_abelmult)"
@@ -141,7 +141,7 @@ Compute the differential of the right group multiplication ``ρ_g(h) = h$(_math(
 
 Due to differences in the representation of some abelian Lie groups, this method wraps a concrete implementation of a specific abelian LieGroup with inputs of type `AbstractArray{<:Any,0}` and supports in-place computation.
 
-This can be computed in-place of `Y` if `Y` is `mutable`.    
+This can be computed in-place of `Y` if `Y` is `mutable`.
 """#
 
 @doc "$(_doc_diff_right_compose_abelmult)"
@@ -301,11 +301,6 @@ function identity_element(
 ) where {𝔽,T<:Number}
     return fill(one(T))
 end
-function identity_element(
-    ::LieGroup{𝔽,AbelianMultiplicationGroupOperation}, e::Number
-) where {𝔽}
-    return one(e)
-end
 
 @doc "$(_doc_identity_element_abelian_mult)"
 identity_element!(::LieGroup{𝔽,AbelianMultiplicationGroupOperation}, e) where {𝔽}
@@ -321,7 +316,7 @@ _doc_lie_bracket_abelmult = """
     lie_bracket!(::LieAlgebra{𝔽,AbelianMultiplicationGroupOperation}, Z, X, Y)
 
 Compute the Lie bracket ``[⋅,⋅]: $(_math(:𝔤))×$(_math(:𝔤)) → $(_math(:𝔤))``,
-which for the for the [`AbelianMultiplicationGroupOperation`](@ref) yields the zero vector of the [`LieAlgebra`](@ref) due to commutativity. 
+which for the for the [`AbelianMultiplicationGroupOperation`](@ref) yields the zero vector of the [`LieAlgebra`](@ref) due to commutativity.
 
 ```math
 [X, Y] = XY-YX = 0

--- a/src/groups/circle_group_sphere.jl
+++ b/src/groups/circle_group_sphere.jl
@@ -89,7 +89,12 @@ function _compose!(::_PlanarCircleGroup, k, g, h)
     return k
 end
 
-identity_element(::_PlanarCircleGroup, ::Type{<:AbstractVector}) = [1.0, 0.0]
+function identity_element(G::_PlanarCircleGroup)
+    return identity_element(G, AbstractVector)
+end
+function identity_element(::_PlanarCircleGroup, ::Type{<:AbstractVector})
+    return [1.0, 0.0]
+end
 function identity_element(::_PlanarCircleGroup, ::Type{<:AbstractVector{T}}) where {T}
     return [one(T), zero(T)]
 end

--- a/src/groups/circle_group_sphere.jl
+++ b/src/groups/circle_group_sphere.jl
@@ -89,9 +89,12 @@ function _compose!(::_PlanarCircleGroup, k, g, h)
     return k
 end
 
-identity_element(::_PlanarCircleGroup) = [1.0, 0.0]
-function identity_element!(::_PlanarCircleGroup, p::Array{<:Any,1})
-    p = [1.0, 0.0]
+identity_element(::_PlanarCircleGroup, ::Type{<:AbstractVector}) = [1.0, 0.0]
+function identity_element(::_PlanarCircleGroup, ::Type{<:AbstractVector{T}}) where {T}
+    return [one(T), zero(T)]
+end
+function identity_element!(::_PlanarCircleGroup, p::V) where {T,V<:AbstractVector{T}}
+    p .= [one(T), zero(T)]
     return p
 end
 

--- a/src/groups/power_group.jl
+++ b/src/groups/power_group.jl
@@ -232,6 +232,14 @@ function ManifoldsBase.hat!(
     return X
 end
 
+function LieGroups.identity_element(
+    PoG::LieGroup{𝔽,Op,M}, ::Type{Vector{T}}
+) where {𝔽,Op<:PowerGroupOperation,M<:ManifoldsBase.AbstractPowerManifold,T}
+    PM = PoG.manifold
+    G = LieGroup(PM.manifold, PoG.op.op)
+    return [identity_element(G, T) for _ in ManifoldsBase.get_iterator(PM)]
+end
+
 function identity_element!(
     PoG::LieGroup{𝔽,Op,M}, e
 ) where {𝔽,Op<:PowerGroupOperation,M<:ManifoldsBase.AbstractPowerManifold}

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -510,6 +510,9 @@ function identity_element(G::SpecialEuclideanGroup, ::Type{<:AbstractMatrix{T}})
     q = zeros(T, ManifoldsBase.representation_size(G)...)
     return identity_element!(G, q)
 end
+function identity_element(G::SpecialEuclideanGroup, ::Type{<:SpecialEuclideanMatrixPoint})
+    return SpecialEuclideanMatrixPoint(identity_element(G, AbstractMatrix{Float64}))
+end
 function identity_element(
     G::SpecialEuclideanGroup, ::Type{<:SpecialEuclideanMatrixPoint{<:AbstractMatrix{T}}}
 ) where {T}
@@ -770,6 +773,18 @@ function ManifoldsBase.representation_size(G::SpecialEuclideanGroup)
     return (s + 1, s + 1)
 end
 
+function Random.rand(
+    rng::AbstractRNG, G::SEG, T::Type=Matrix{Float64}; kwargs...
+) where {SEG<:SpecialEuclideanGroup}
+    g = identity_element(G, T)
+    return rand!(rng, G, g; kwargs...)
+end
+function Random.rand(
+    G::SEG, T::Type=Matrix{Float64}; kwargs...
+) where {SEG<:SpecialEuclideanGroup}
+    g = identity_element(G, T)
+    return rand!(G, g; kwargs...)
+end
 # this is always with vector_at=nothing
 function Random.rand!(
     rng::AbstractRNG,

--- a/src/groups/special_orthogonal_group.jl
+++ b/src/groups/special_orthogonal_group.jl
@@ -70,6 +70,14 @@ ManifoldsBase.get_vector!(
     ::DefaultLieAlgebraOrthogonalBasis,
 )
 
+function identity_element(G::SpecialOrthogonalGroup)
+    return identity_element(G, AbstractMatrix{Float64})
+end
+function identity_element(G::SpecialOrthogonalGroup, ::Type{<:AbstractMatrix{T}}) where {T}
+    e = zeros(T, ManifoldsBase.representation_size(G)...)
+    return identity_element!(G, e)
+end
+
 inv!(G::SpecialOrthogonalGroup, k, g) = copyto!(G, k, transpose(g))
 function inv!(
     G::SpecialOrthogonalGroup, q, ::Identity{O}

--- a/src/groups/unitary_group.jl
+++ b/src/groups/unitary_group.jl
@@ -62,9 +62,10 @@ function ManifoldsBase.exp!(
 end
 
 function identity_element(
-    ::UnitaryGroup{ManifoldsBase.ℍ,ManifoldsBase.TypeParameter{Tuple{1}}}
-)
-    return Quaternions.quat(1.0)
+    ::UnitaryGroup{ManifoldsBase.ℍ,ManifoldsBase.TypeParameter{Tuple{1}}},
+    ::Type{<:Quaternion{T}},
+) where {T}
+    return Quaternions.quat(one(T))
 end
 
 function identity_element(

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -94,6 +94,10 @@ unwrap_validation(v) = v
 unwrap_validation(vTV::ValidationLieAlgebraTangentVector) = vTV.value
 unwrap_validation(vP::ValidationMPoint) = vP.value
 
+unwrap_validation_type(v) = v
+unwrap_validation_type(::Type{<:ValidationLieAlgebraTangentVector{T}}) where {T} = T
+unwrap_validation_type(::Type{<:ValidationMPoint{<:P}}) where {P} = P
+
 #
 #
 # An access helper function
@@ -377,7 +381,7 @@ function ManifoldsBase.hat(
     𝔤::LieAlgebra{𝔽,O,<:ValidationLieGroup}, c, T::Type; kwargs...
 ) where {𝔽,O<:AbstractGroupOperation}
     G = base_lie_group(𝔤).lie_group
-    X = hat(LieAlgebra(G), c, T)
+    X = hat(LieAlgebra(G), c, unwrap_validation_type(T))
     is_point(𝔤, X; widthin=hat, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(X)
 end
@@ -391,16 +395,7 @@ function ManifoldsBase.hat!(
 end
 
 function identity_element(G::ValidationLieGroup, ::Type{T}; kwargs...) where {T}
-    g = identity_element(G.lie_group, T)
-    is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
-    return ValidationMPoint(g)
-end
-function identity_element(
-    G::ValidationLieGroup,
-    ::Type{<:ValidationMPoint{T}};
-    kwargs...,
-) where {T}
-    g = identity_element(G.lie_group, T)
+    g = identity_element(G.lie_group, unwrap_validation_type(T))
     is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
     return ValidationMPoint(g)
 end

--- a/src/groups/validation_group.jl
+++ b/src/groups/validation_group.jl
@@ -390,12 +390,20 @@ function ManifoldsBase.hat!(
     return X
 end
 
-function identity_element(G::ValidationLieGroup; kwargs...)
-    g = identity_element(G.lie_group)
+function identity_element(G::ValidationLieGroup, ::Type{T}; kwargs...) where {T}
+    g = identity_element(G.lie_group, T)
     is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
     return ValidationMPoint(g)
 end
-
+function identity_element(
+    G::ValidationLieGroup,
+    ::Type{<:ValidationMPoint{T}};
+    kwargs...,
+) where {T}
+    g = identity_element(G.lie_group, T)
+    is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
+    return ValidationMPoint(g)
+end
 function identity_element!(G::ValidationLieGroup, g; kwargs...)
     identity_element!(G.lie_group, unwrap_validation(g))
     is_point(G, g; widthin=identity_element, context=(:Output,), kwargs...)
@@ -627,13 +635,22 @@ function Base.log(
     return ValidationLieAlgebraTangentVector(X)
 end
 function Base.log(
-    G::ValidationLieGroup{𝔽,O}, e::Identity{O}, T::Type; kwargs...
-) where {𝔽,O<:AbstractGroupOperation}
+    G::ValidationLieGroup{𝔽,O}, e::Identity{O}, ::Type{T}; kwargs...
+) where {𝔽,O<:AbstractGroupOperation,T}
     X = log(G.lie_group, e, T)
     is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
     return ValidationLieAlgebraTangentVector(X)
 end
-
+function Base.log(
+    G::ValidationLieGroup{𝔽,O},
+    e::Identity{O},
+    ::Type{<:ValidationLieAlgebraTangentVector{T}};
+    kwargs...,
+) where {𝔽,O<:AbstractGroupOperation,T}
+    X = log(G.lie_group, e, T)
+    is_point(LieAlgebra(G), X; widthin=log, context=(:Output,), kwargs...)
+    return ValidationLieAlgebraTangentVector(X)
+end
 function ManifoldsBase.log!(G::ValidationLieGroup, X, g; kwargs...)
     is_point(G, g; widthin=log, context=(:Input,), kwargs...)
     log!(G.lie_group, unwrap_validation(X), unwrap_validation(g))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -481,10 +481,6 @@ function identity_element(G::AbstractLieGroup)
     e = ManifoldsBase.allocate_result(G, identity_element)
     return identity_element!(G, e)
 end
-# Fallback over to default
-function identity_element(G::AbstractLieGroup, ::Type)
-    return identity_element(G)
-end
 
 function identity_element! end
 @doc "$(_doc_identity_element)"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -834,6 +834,17 @@ function ManifoldsBase.project!(G::AbstractLieGroup, g, p)
     return ManifoldsBase.project!(base_manifold(G), g, p)
 end
 
+# TODO: Move to ManifoldsBase at some point
+"""
+    point_type(G::AbstractLieGroup, tangent_vector_type::Type)
+
+Change `tangent_vector_type` that is a type of tangent vector type on Lie group `G`
+to its matching type for representing points.
+
+By default both these types are assumed to be identical.
+"""
+point_type(::AbstractLieGroup, tangent_vector_type::Type) = tangent_vector_type
+
 @doc "$(_doc_rand)"
 Random.rand(::AbstractLieGroup; kwargs...)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -262,7 +262,7 @@ ManifoldsBase.copyto!(G::AbstractLieGroup, h, g) = copyto!(base_manifold(G), h, 
 function ManifoldsBase.copyto!(
     G::AbstractLieGroup{𝔽,O}, h::P, ::Identity{O}
 ) where {𝔽,O<:AbstractGroupOperation,P}
-    return ManifoldsBase.copyto!(base_manifold(G), h, identity_element(G, P))
+    return identity_element!(G, h)
 end
 function ManifoldsBase.copyto!(
     ::AbstractLieGroup{𝔽,O}, h::Identity{O}, ::Identity{O}

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -66,7 +66,7 @@ Test  `adjoint` function for a given Lie group element `g` and a Lie Algebra vec
 function test_adjoint(G::AbstractLieGroup, g, X; expected=missing, test_mutating::Bool=true)
     @testset "adjoint" begin
         v = if ismissing(expected)
-            diff_conjugate(G, g, identity_element(G, typeof(X)), X)
+            diff_conjugate(G, g, identity_element(G, typeof(g)), X)
         else
             expected
         end
@@ -308,7 +308,7 @@ function test_diff_inv(
     @testset "diff_inv" begin
         𝔤 = LieAlgebra(G)
         # Check that at identity it is in the Lie algebra
-        Ye = diff_inv(G, identity_element(G, typeof(X)), X)
+        Ye = diff_inv(G, identity_element(G, typeof(g)), X)
         @test is_point(𝔤, Ye; error=:error)
         Y1 = diff_inv(G, g, X)
         if test_mutating
@@ -337,7 +337,7 @@ function test_diff_left_compose(
 )
     @testset "diff_left_compose" begin
         𝔤 = LieAlgebra(G)
-        Ye = diff_left_compose(G, identity_element(G, typeof(X)), h, X)
+        Ye = diff_left_compose(G, identity_element(G, typeof(g)), h, X)
         @test is_point(𝔤, Ye; error=:error)
         # check that in-place and allocating agree
         Y1 = diff_left_compose(G, g, h, X)
@@ -367,7 +367,7 @@ function test_diff_right_compose(
 )
     @testset "diff_right_compose" begin
         𝔤 = LieAlgebra(G)
-        Ye = diff_right_compose(G, identity_element(G, typeof(X)), h, X)
+        Ye = diff_right_compose(G, identity_element(G, typeof(g)), h, X)
         @test is_point(𝔤, Ye; error=:error)
         # check that in-place and allocating agree
         Y1 = diff_right_compose(G, g, h, X)

--- a/test/groups/test_circle_group.jl
+++ b/test/groups/test_circle_group.jl
@@ -126,5 +126,6 @@ using LieGroupsTestSuite
         )
         expectations = Dict(:repr => "CircleGroup(Sphere(1))")
         test_lie_group(C1, properties, expectations)
+        @test identity_element(C1) == [1.0, 0.0]
     end
 end

--- a/test/groups/test_special_euclidean_group.jl
+++ b/test/groups/test_special_euclidean_group.jl
@@ -228,6 +228,11 @@ using LieGroupsTestSuite
 
             @test norm(LieAlgebra(G2l), X4) == norm(X1)
         end
+        @testset "Identity element special cases" begin
+            @test identity_element(G2l) == one(zeros(3, 3))
+            g = identity_element(G2l, SpecialEuclideanMatrixPoint)
+            @test g == SpecialEuclideanMatrixPoint(one(zeros(3, 3)))
+        end
     end
     @testset "Zero vector special types" begin
         G2l = SpecialEuclideanGroup(2)

--- a/test/groups/test_special_linear_group.jl
+++ b/test/groups/test_special_linear_group.jl
@@ -42,7 +42,7 @@ using LieGroupsTestSuite
     @testset "Complex SL(2)" begin
         G = SpecialLinearGroup(2, ℂ)
         g1, g2, g3 = [1.0im 0.0; 0.0 -1.0im], [1.25 0.5; 0.5 1.0], [1.0 1.0; 3.0 4.0]
-        X1, X2, X3 = [0.0 -1.0; 0.0 0.0], [0.0 0.5; 0.5 0.0], [-1.0 0.0; 0.0 1.0]
+        X1, X2, X3 = [0.0im -1.0; 0.0 0.0], [0.0im 0.5; 0.5 0.0], [-1.0 0.0im; 0.0 1.0]
         properties = Dict(
             :Name => "The complex special linear group",
             :Points => [g1, g2, g3],

--- a/test/groups/test_unitary_group.jl
+++ b/test/groups/test_unitary_group.jl
@@ -69,6 +69,7 @@ using LieGroupsTestSuite
             Dict(:Name => "The quaternion unitary group", :Functions => [show]),
             expectations2,
         )
+        @test identity_element(G, QuaternionF64) == Quaternions.quat(1.0)
     end
     @testset "Quaternion Unitary group (1x1 matrices)" begin
         G = UnitaryGroup(1, ℍ)
@@ -93,5 +94,7 @@ using LieGroupsTestSuite
             Dict(:Name => "The quaternion unitary group", :Functions => [show]),
             expectations2,
         )
+
+        @test identity_element(G) isa Matrix{QuaternionF64}
     end
 end

--- a/test/operations/test_multiplication_operation.jl
+++ b/test/operations/test_multiplication_operation.jl
@@ -52,7 +52,7 @@ using LieGroupsTestSuite
             LieGroupsTestSuite.DummyManifold(), AbelianMultiplicationGroupOperation()
         )
         # Edge case: Number element
-        @test identity_element(G, 0.0) == 1.0
+        @test identity_element(G, Float64) == 1.0
         # Edge case: Mixed compose
         @test compose(G, fill(1.0), 1.0) == 1.0
         @test compose(G, 1.0, fill(1.0)) == 1.0


### PR DESCRIPTION
Once finished, should fix #39.

For now this PR does achieve

```
julia> using LieGroups

julia> G = SpecialEuclideanGroup(2; variant=:right)
SpecialEuclideanGroup(2; variant=:right)

julia> identity_element(G)
3×3 Matrix{Float64}:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0

julia> rand(G)
3×3 Matrix{Float64}:
  0.313702  0.949522   0.309771
 -0.949522  0.313702  -0.994399
  0.0       0.0        1.0
```

but it is more tricky, since we had a variant of `identity_element(G,T)` that dispatched just to drop `T`. That led to `T=SpecialEuclideanProductPoint` returning the matrix when `RecursiveArrayTools` are not loaded – as well as when it was loaded, since the extension only does that correctly if one also provides the internal `ArrayPartition` _including_ its parameters. 

That I could not yet resolve and would need some help with or a few weeks to ponder about.
It seems the default “drop `T`” is maybe not so good of a default, but dropping that for now lets about 400 tests fail – so also there I am a bit lost what to do.

So for now this is a very rough draft of what might fix the above mentioned issue since I have no idea how to continue, but I tried for most of the afternoon.