### PR TITLE
Add a `identity_element` test to the Test suite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,13 @@ All notable Changes to the Julia package `LieGroups.jl` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] 2025-06-22
+## [0.1.2] 2025-06-23
 
 ### Added
 
 * `is_flat` for `SpecialEuclideanGroup`
 * `inner` and `norm` for `LieAlgebra` to compute the inner product and norm on the Lie algebra.
+* a test suite function for `identity_element`.
 
 ### Changed
 


### PR DESCRIPTION
Interestingly that function was already in a few lists for groups, so it was even used automatically.

This resolves #46.