### PR TITLE
Slightly improve news.html

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `get_vector` on `SpecialEuclideanGroup` with `ArrayPartition` point type.
 * `identity_element` and `zero_vector` are now all using a type as second argument and
   respect this type more thoroughly.
-* Issue #44 (accuracy of `log` on SE(2) and SE(3) for small angles).
+* fixes (#44) (accuracy of `log` on SE(2) and SE(3) for small angles).
 
 ## [0.1.1] 2025-05-05
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -99,6 +99,23 @@ using DocumenterCitations, DocumenterInterLinks
 using LinearAlgebra
 using LieGroups
 
+# (e) add contributing.md and changelog.md to the docs – and link to releases and issues
+
+function add_links(line::String, url::String="https://github.com/JuliaManifolds/Liegroups.jl")
+    # replace issues (#XXXX) -> ([#XXXX](url/issue/XXXX))
+    while (m = match(r"\(\#([0-9]+)\)", line)) !== nothing
+        id = m.captures[1]
+        line = replace(line, m.match => "([#$id]($url/issues/$id))")
+    end
+    # replace ## [X.Y.Z] -> with a link to the release [X.Y.Z](url/releases/tag/vX.Y.Z)
+    while (m = match(r"\#\# \[([0-9]+.[0-9]+.[0-9]+)\] (.*)", line)) !== nothing
+        tag = m.captures[1]
+        date = m.captures[2]
+        line = replace(line, m.match => "## [$tag]($url/releases/tag/v$tag) ($date)")
+    end
+    return line
+end
+
 # (e) add contributing.md to docs
 generated_path = joinpath(@__DIR__, "src")
 base_url = "https://github.com/JuliaManifolds/LieGroups.jl/blob/main/"
@@ -116,7 +133,7 @@ for (md_file, doc_file) in [("CONTRIBUTING.md", "contributing.md"), ("NEWS.md", 
         )
         # Write the contents out below the meta block
         for line in eachline(joinpath(dirname(@__DIR__), md_file))
-            println(io, line)
+            println(io, add_links(line))
         end
     end
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -101,7 +101,9 @@ using LieGroups
 
 # (e) add contributing.md and changelog.md to the docs – and link to releases and issues
 
-function add_links(line::String, url::String="https://github.com/JuliaManifolds/Liegroups.jl")
+function add_links(
+    line::String, url::String="https://github.com/JuliaManifolds/Liegroups.jl"
+)
     # replace issues (#XXXX) -> ([#XXXX](url/issue/XXXX))
     while (m = match(r"\(\#([0-9]+)\)", line)) !== nothing
         id = m.captures[1]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -102,7 +102,7 @@ using LieGroups
 # (e) add contributing.md and changelog.md to the docs – and link to releases and issues
 
 function add_links(
-    line::String, url::String="https://github.com/JuliaManifolds/Liegroups.jl"
+    line::String, url::String="https://github.com/JuliaManifolds/LieGroups.jl"
 )
     # replace issues (#XXXX) -> ([#XXXX](url/issue/XXXX))
     while (m = match(r"\(\#([0-9]+)\)", line)) !== nothing


### PR DESCRIPTION
Just by chance I saw that a new entry in the `NEWS.md` was linking to an issue. So I adapted something I did in `Manopt.jl` here, and reformatted the text just slightly-

* anything of the form `(#xx)` where `xx` is a number links automatically to the issue on GitHub, so when rendered into the docs, these are found by an regex and also replaced to link to the issue as well.
* anything of the form `## [X.Y.Z] `, i.e. headlines in the news now links to the release pages on GitHub.