### PR TITLE
hat/vee and get_vector improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed a typo, where `within` was misspelled as `widthin` which caused errors in a few places.
+* fix `default_basis` for `LieGroup` to return a `DefaultLieAlgebraOrthogonalBasis` also when providing a point type. That way `get_vector` falls back to the manifold when called with a Lie group and a point, though this is mere a historical format and the Lie algebra approach is the recommended one.
+* mention `get_coordinates`, `get_vector`, `hat`, and `vee` in the transition documentation since it moved to using the `LieAlgebra` instead of the Lie group and a point.
 
 ## [0.1.2] 2025-06-24
 

--- a/docs/src/tutorials/transition.md
+++ b/docs/src/tutorials/transition.md
@@ -40,8 +40,9 @@ The list is alphabetical, but first lists types, then functions
 | `exp(G, g, X)` | `exp(`[`base_manifold`](@ref base_manifold(G::LieGroup))`(G), g, X)` | the previous defaults whenever not agreeing with the Riemannian one can now be accessed on the internal manifold |
 | `exp_inv(G, g, X)` | [`exp`](@ref exp(G::LieGroup, g, X))`(G, g, X)`  | the exponential map invariant to the group operation is the default on Lie groups here |
 | `exp_lie(G, X)` | [`exp`](@ref exp(G::LieGroup, X))`(G, X)` | the (matrix/Lie group) exponential |
-| `get_vector(G, p, c)` | [`get_vector`](@ref hat(G::Algebra, c))`(`[`LieAlgebra`](@ref)`(G), c[, T])` | moved to using the new [`LieAlgebra`](@ref). The old format should still work. `T` indicates the type of tangent vector. |
-| `hat(G, p, c)` | [`hat`](@ref hat(G::Algebra, c))`(`[`LieAlgebra`](@ref)`(G), p, c[, T])` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. `T`indicates the type of tangent vector . |
+| `get_coordinates(G, p, X)` | [`get_coordinates`](@ref get_coordinates(G::LieAlgebra))`(`[`LieAlgebra`](@ref)`(G), X)` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. |
+| `get_vector(G, p, c)` | [`get_vector`](@ref get_vector(::LieAlgebra))`(`[`LieAlgebra`](@ref)`(G), c[, T])` | moved to using the new [`LieAlgebra`](@ref). The old format should still work. `T` indicates the type of tangent vector. |
+| `hat(G, p, c)` | [`hat`](@ref hat(G::LieAlgebra))`(`[`LieAlgebra`](@ref)`(G), p, c[, T])` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. `T` indicates the type of tangent vector. |
 | `inner(G, g, X, Y)` | [`inner`](@ref)`(`[`LieAlgebra`](@ref)`(G), X, Y)` | the inner product on the Lie Algebra. The old variant still calls the new one.|
 | `inverse_translate(G, g, h, c)` | [`inv_left_compose`](@ref)`(G, g, h)`, [`inv_right_compose`](@ref)`(G, g, h)` | compute ``g^{-1}∘h`` and ``g∘h^{-1}``, resp. |
 | `inverse_translate_diff(G, g, h, X, LeftForwardAction())` | - | discontinued, use `diff_left_compose(G, inv(G,g), h)` |
@@ -54,7 +55,7 @@ The list is alphabetical, but first lists types, then functions
 | `switch_side(A)` | [`switch`](@ref switch(::GroupAction))`(A)` | switches from a left action to its corresponding right action. |
 | `translate(G, g, h)` | [`compose`](@ref)`(G, g, h)` | unified to `compose` |
 | `translate_diff(G, g, X, c)` | [`diff_left_compose`](@ref)`(G, g, h, X)`, [`diff_right_compose`](@ref)`(G, g, h, X)` | for compose ``g∘h`` the functions now specify whether the derivative is taken w.r.t. to the left (`g`) or right (`h`) argument |
-| `vee(G, p, X)` | [`hat`](@ref hat(G::Algebra, c))`(`[`LieAlgebra`](@ref)`(G), p, c)` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. |
+| `vee(G, p, X)` | [`vee`](@ref vee(G::LieAlgebra, X))`(`[`LieAlgebra`](@ref)`(G), X)` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. |
 | `VeeOrthogonalBasis` | [`DefaultLieAlgebraOrthogonalBasis`](@ref) | |
 
 ## Further notable changes

--- a/docs/src/tutorials/transition.md
+++ b/docs/src/tutorials/transition.md
@@ -40,6 +40,8 @@ The list is alphabetical, but first lists types, then functions
 | `exp(G, g, X)` | `exp(`[`base_manifold`](@ref base_manifold(G::LieGroup))`(G), g, X)` | the previous defaults whenever not agreeing with the Riemannian one can now be accessed on the internal manifold |
 | `exp_inv(G, g, X)` | [`exp`](@ref exp(G::LieGroup, g, X))`(G, g, X)`  | the exponential map invariant to the group operation is the default on Lie groups here |
 | `exp_lie(G, X)` | [`exp`](@ref exp(G::LieGroup, X))`(G, X)` | the (matrix/Lie group) exponential |
+| `get_vector(G, p, c)` | [`get_vector`](@ref hat(G::Algebra, c))`(`[`LieAlgebra`](@ref)`(G), c[, T])` | moved to using the new [`LieAlgebra`](@ref). The old format should still work. `T` indicates the type of tangent vector. |
+| `hat(G, p, c)` | [`hat`](@ref hat(G::Algebra, c))`(`[`LieAlgebra`](@ref)`(G), p, c[, T])` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. `T`indicates the type of tangent vector . |
 | `inner(G, g, X, Y)` | [`inner`](@ref)`(`[`LieAlgebra`](@ref)`(G), X, Y)` | the inner product on the Lie Algebra. The old variant still calls the new one.|
 | `inverse_translate(G, g, h, c)` | [`inv_left_compose`](@ref)`(G, g, h)`, [`inv_right_compose`](@ref)`(G, g, h)` | compute ``g^{-1}∘h`` and ``g∘h^{-1}``, resp. |
 | `inverse_translate_diff(G, g, h, X, LeftForwardAction())` | - | discontinued, use `diff_left_compose(G, inv(G,g), h)` |
@@ -52,6 +54,7 @@ The list is alphabetical, but first lists types, then functions
 | `switch_side(A)` | [`switch`](@ref switch(::GroupAction))`(A)` | switches from a left action to its corresponding right action. |
 | `translate(G, g, h)` | [`compose`](@ref)`(G, g, h)` | unified to `compose` |
 | `translate_diff(G, g, X, c)` | [`diff_left_compose`](@ref)`(G, g, h, X)`, [`diff_right_compose`](@ref)`(G, g, h, X)` | for compose ``g∘h`` the functions now specify whether the derivative is taken w.r.t. to the left (`g`) or right (`h`) argument |
+| `vee(G, p, X)` | [`hat`](@ref hat(G::Algebra, c))`(`[`LieAlgebra`](@ref)`(G), p, c)` | hat/vee moved to using the new [`LieAlgebra`](@ref). The old format should still work. |
 | `VeeOrthogonalBasis` | [`DefaultLieAlgebraOrthogonalBasis`](@ref) | |
 
 ## Further notable changes

--- a/src/groups/orthogonal_group.jl
+++ b/src/groups/orthogonal_group.jl
@@ -186,9 +186,10 @@ end
 function ManifoldsBase.exp(
     G::CommonUnitarySubGroup{ManifoldsBase.ℝ,ManifoldsBase.TypeParameter{Tuple{2}}},
     p::SMatrix,
-    X::SMatrix,
-)
-    θ = get_coordinates(G, p, X)[1]
+    X::SMatrix{2,2,T},
+) where {T}
+    # Use the default orthogonal basis and not vee
+    θ = X[2] * sqrt(T(2))
     sinθ, cosθ = sincos(θ)
     return p * SA[cosθ -sinθ; sinθ cosθ]
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -281,7 +281,14 @@ function ManifoldsBase.copyto!(
     )
 end
 
-ManifoldsBase.default_basis(::AbstractLieGroup) = DefaultLieAlgebraOrthogonalBasis()
+function ManifoldsBase.default_basis(
+    ::AbstractLieGroup, ::Type{T}; field::AbstractNumbers=ℝ
+) where {T}
+    return DefaultLieAlgebraOrthogonalBasis(field)
+end
+function ManifoldsBase.default_basis(::AbstractLieGroup; field::AbstractNumbers=ℝ)
+    return DefaultLieAlgebraOrthogonalBasis(field)
+end
 
 _doc_diff_conjugate = """
     diff_conjugate(G::AbstractLieGroup, g, h, X)


### PR DESCRIPTION
Fix #54.

The reason the (though outdated) `get_vector` on a `LieGroup` did not work was, that in one case we forgot to set the default correctly to the `Vee` basis.
This usually does not have much of an effect, since then the manifold “takes over” – but for exactly one case, SE(n) in homogeneous coordinates, the manifold can't do that on its product.

This is now fixed.
Also the transition is extended about these cases.

@mateuszbaran for me now 2 tests on `O(2)` fail. Since I did not change anything in `exp` and `exo_fused` I am not sure why that appears, since it is checks against “magic numbers” I am not sure what is happening nor do I have any chance to understand those `SA`s.
We discussed that, and this is exactly why I do not like such test. Can you take a look?