### PR TITLE
Add the lie_bracket for the SpecialEuclideanGroup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a typo, where `within` was misspelled as `widthin` which caused errors in a few places.
 * fix `default_basis` for `LieGroup` to return a `DefaultLieAlgebraOrthogonalBasis` also when providing a point type. That way `get_vector` falls back to the manifold when called with a Lie group and a point, though this is mere a historical format and the Lie algebra approach is the recommended one.
 * mention `get_coordinates`, `get_vector`, `hat`, and `vee` in the transition documentation since it moved to using the `LieAlgebra` instead of the Lie group and a point.
+* Add `lie_bracket` for the SpecialEuclideanGroup.
 
 ## [0.1.2] 2025-06-24
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,7 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 LieGroups = "6774de46-80ba-43f8-ba42-e41071ccfc5f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -154,7 +154,7 @@ makedocs(;
         size_threshold_warn=200 * 2^10, # raise slightly from 100 to 200 KiB
         size_threshold=300 * 2^10,      # raise slightly 200 to to 300 KiB
     ),
-    modules=[LieGroups,  Base.get_extension(LieGroups, :LieGroupsRecursiveArrayToolsExt),],
+    modules=[LieGroups, Base.get_extension(LieGroups, :LieGroupsRecursiveArrayToolsExt)],
     authors="Seth Axen, Mateusz Baran, Ronny Bergmann, Olivier Verdier, and contributors",
     sitename="LieGroups.jl",
     pages=[

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -98,6 +98,7 @@ using Documenter
 using DocumenterCitations, DocumenterInterLinks
 using LinearAlgebra
 using LieGroups
+using RecursiveArrayTools
 
 # (e) add contributing.md and changelog.md to the docs – and link to releases and issues
 
@@ -153,7 +154,7 @@ makedocs(;
         size_threshold_warn=200 * 2^10, # raise slightly from 100 to 200 KiB
         size_threshold=300 * 2^10,      # raise slightly 200 to to 300 KiB
     ),
-    modules=[LieGroups],
+    modules=[LieGroups,  Base.get_extension(LieGroups, :LieGroupsRecursiveArrayToolsExt),],
     authors="Seth Axen, Mateusz Baran, Ronny Bergmann, Olivier Verdier, and contributors",
     sitename="LieGroups.jl",
     pages=[

--- a/ext/LieGroupsRecursiveArrayToolsExt/LieGroupsRecursiveArrayToolsExt.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/LieGroupsRecursiveArrayToolsExt.jl
@@ -4,7 +4,7 @@ using LieGroups
 using RecursiveArrayTools: ArrayPartition
 using LinearAlgebra
 using ManifoldsBase
-using ManifoldsBase: base_manifold, submanifold_components
+using ManifoldsBase: base_manifold, submanifold_components, submanifold_component
 
 include("special_euclidean_group_RAT_ext.jl")
 

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -186,6 +186,37 @@ function LinearAlgebra.norm(
     return LinearAlgebra.norm([n1, n2])
 end
 
+"""
+    lie_bracket(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclidean}, X::ArrayPartition, Y::ArrayPartition)
+    lie_bracket!(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclidean}, Z::ArrayPartition, X::ArrayPartition, Y::ArrayPartition)
+
+Calculate the Lie bracket between elements `X` and `Y` of the special Euclidean Lie
+algebra. For the matrix representation the formula is ``[X, Y] = XY-YX``, while in the `ArrayPartition` representation the
+formula reads ``[X, Y] = [(X_t, X_R), (Y_t, Y_R)] = (X_R * Y_t - Y_R * X_t, X_R * Y_R - Y_R * X_R)``.
+"""
+function LieGroups.lie_bracket!(
+    𝔤::LieGroups.LieAlgebra{
+        ℝ,
+        <:LieGroups.SpecialEuclideanGroupOperation,
+        <:LieGroups.SpecialEuclideanGroup,
+    },
+    Z::ArrayPartition,
+    X::ArrayPartition,
+    Y::ArrayPartition,
+)
+    G = LieGroups.base_lie_group(𝔤)
+    SOn, _ = LieGroups._SOn_and_Tn(G)
+    X_t = submanifold_components(G, X, :Translation)
+    X_R = submanifold_components(G, X, :Rotation)
+    Y_t = submanifold_components(G, Y, :Translation)
+    Y_R = submanifold_components(G, Y, :Rotation)
+    Z_t = submanifold_components(G, Z, :Translation)
+    Z_R = submanifold_components(G, Z, :Rotation)
+    LieGroups.lie_bracket!(LieAlgebra(SOn), Z_R, X_R, Y_R)
+    Z_t .= X_R * Y_t .- Y_R * X_t
+    return Z
+end
+
 function ManifoldsBase.submanifold_component(
     G::LieGroups.LeftSpecialEuclideanGroup,
     g::Union{ArrayPartition,SpecialEuclideanProductPoint},

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -196,9 +196,7 @@ formula reads ``[X, Y] = [(X_t, X_R), (Y_t, Y_R)] = (X_R * Y_t - Y_R * X_t, X_R 
 """
 function LieGroups.lie_bracket!(
     𝔤::LieGroups.LieAlgebra{
-        ℝ,
-        <:LieGroups.SpecialEuclideanGroupOperation,
-        <:LieGroups.SpecialEuclideanGroup,
+        ℝ,<:LieGroups.SpecialEuclideanGroupOperation,<:LieGroups.SpecialEuclideanGroup
     },
     Z::ArrayPartition,
     X::ArrayPartition,

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -204,12 +204,12 @@ function LieGroups.lie_bracket!(
 )
     G = LieGroups.base_lie_group(𝔤)
     SOn, _ = LieGroups._SOn_and_Tn(G)
-    X_t = submanifold_components(G, X, :Translation)
-    X_R = submanifold_components(G, X, :Rotation)
-    Y_t = submanifold_components(G, Y, :Translation)
-    Y_R = submanifold_components(G, Y, :Rotation)
-    Z_t = submanifold_components(G, Z, :Translation)
-    Z_R = submanifold_components(G, Z, :Rotation)
+    X_t = submanifold_component(G, X, :Translation)
+    X_R = submanifold_component(G, X, :Rotation)
+    Y_t = submanifold_component(G, Y, :Translation)
+    Y_R = submanifold_component(G, Y, :Rotation)
+    Z_t = submanifold_component(G, Z, :Translation)
+    Z_R = submanifold_component(G, Z, :Rotation)
     LieGroups.lie_bracket!(LieAlgebra(SOn), Z_R, X_R, Y_R)
     Z_t .= X_R * Y_t .- Y_R * X_t
     return Z

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -186,14 +186,34 @@ function LinearAlgebra.norm(
     return LinearAlgebra.norm([n1, n2])
 end
 
-"""
-    lie_bracket(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclidean}, X::ArrayPartition, Y::ArrayPartition)
-    lie_bracket!(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclidean}, Z::ArrayPartition, X::ArrayPartition, Y::ArrayPartition)
+_doc_lie_bracket_SEn_RAT = """
+    lie_bracket(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclideanGroup}, X::ArrayPartition, Y::ArrayPartition)
+    lie_bracket!(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclideanGroup}, Z::ArrayPartition, X::ArrayPartition, Y::ArrayPartition)
 
-Calculate the Lie bracket between elements `X` and `Y` of the special Euclidean Lie
-algebra. For the matrix representation the formula is ``[X, Y] = XY-YX``, while in the `ArrayPartition` representation the
-formula reads ``[X, Y] = [(X_t, X_R), (Y_t, Y_R)] = (X_R * Y_t - Y_R * X_t, X_R * Y_R - Y_R * X_R)``.
+Calculate the Lie bracket between elements `X` and `Y` of the Lie algebra of the [`SpecialEuclideanGroup`](@ref).
+For the representation as a matrix and a vector, cf. [`SpecialEuclideanProductTangentVector`](@ref) or a `ArrayPartition`
+every Lie algebra element is represented as a pair ``X = (X_{$(LieGroups._tex(:text, "R"))}, X_$(LieGroups._tex(:text, "t")))``
+or a rotation matrix and a translation vector, respectively.
+
+Then the formula for the Lie bracket is given by
+```math
+[X, Y] = [(X_{$(LieGroups._tex(:text, "R"))}, X_{$(LieGroups._tex(:text, "t"))}), (Y_{$(LieGroups._tex(:text, "R"))}, Y_{$(LieGroups._tex(:text, "t"))})]
+= (X_{$(LieGroups._tex(:text, "R"))} * Y_{$(LieGroups._tex(:text, "R"))} - Y_{$(LieGroups._tex(:text, "R"))} * X_{$(LieGroups._tex(:text, "R"))}, X_{$(LieGroups._tex(:text, "R"))} * Y_{$(LieGroups._tex(:text, "t"))} - Y_{$(LieGroups._tex(:text, "R"))} * X_{$(LieGroups._tex(:text, "t"))}),
+```
+
+where for the right semidirect product variant, the order of the pair is switched.
 """
+
+"$(_doc_lie_bracket_SEn_RAT)"
+LieGroups.lie_bracket(
+    𝔤::LieGroups.LieAlgebra{
+        ℝ,<:LieGroups.SpecialEuclideanGroupOperation,<:LieGroups.SpecialEuclideanGroup
+    },
+    X::Union{<:ArrayPartition,<:SpecialEuclideanProductTangentVector},
+    Y::Union{<:ArrayPartition,<:SpecialEuclideanProductTangentVector},
+)
+
+"$(_doc_lie_bracket_SEn_RAT)"
 function LieGroups.lie_bracket!(
     𝔤::LieGroups.LieAlgebra{
         ℝ,<:LieGroups.SpecialEuclideanGroupOperation,<:LieGroups.SpecialEuclideanGroup

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -198,9 +198,9 @@ function LieGroups.lie_bracket!(
     𝔤::LieGroups.LieAlgebra{
         ℝ,<:LieGroups.SpecialEuclideanGroupOperation,<:LieGroups.SpecialEuclideanGroup
     },
-    Z::Union{<:ArrayPartition, <:SpecialEuclideanProductTangentVector},
-    X::Union{<:ArrayPartition, <:SpecialEuclideanProductTangentVector},
-    Y::Union{<:ArrayPartition, <:SpecialEuclideanProductTangentVector},
+    Z::Union{<:ArrayPartition,<:SpecialEuclideanProductTangentVector},
+    X::Union{<:ArrayPartition,<:SpecialEuclideanProductTangentVector},
+    Y::Union{<:ArrayPartition,<:SpecialEuclideanProductTangentVector},
 )
     G = LieGroups.base_lie_group(𝔤)
     SOn, _ = LieGroups._SOn_and_Tn(G)

--- a/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
+++ b/ext/LieGroupsRecursiveArrayToolsExt/special_euclidean_group_RAT_ext.jl
@@ -198,18 +198,18 @@ function LieGroups.lie_bracket!(
     𝔤::LieGroups.LieAlgebra{
         ℝ,<:LieGroups.SpecialEuclideanGroupOperation,<:LieGroups.SpecialEuclideanGroup
     },
-    Z::ArrayPartition,
-    X::ArrayPartition,
-    Y::ArrayPartition,
+    Z::Union{<:ArrayPartition, <:SpecialEuclideanProductTangentVector},
+    X::Union{<:ArrayPartition, <:SpecialEuclideanProductTangentVector},
+    Y::Union{<:ArrayPartition, <:SpecialEuclideanProductTangentVector},
 )
     G = LieGroups.base_lie_group(𝔤)
     SOn, _ = LieGroups._SOn_and_Tn(G)
-    X_t = submanifold_component(G, X, :Translation)
-    X_R = submanifold_component(G, X, :Rotation)
-    Y_t = submanifold_component(G, Y, :Translation)
-    Y_R = submanifold_component(G, Y, :Rotation)
-    Z_t = submanifold_component(G, Z, :Translation)
-    Z_R = submanifold_component(G, Z, :Rotation)
+    X_t = submanifold_component(LieAlgebra(G), X, Val(:Translation))
+    X_R = submanifold_component(LieAlgebra(G), X, Val(:Rotation))
+    Y_t = submanifold_component(LieAlgebra(G), Y, Val(:Translation))
+    Y_R = submanifold_component(LieAlgebra(G), Y, Val(:Rotation))
+    Z_t = submanifold_component(LieAlgebra(G), Z, Val(:Translation))
+    Z_R = submanifold_component(LieAlgebra(G), Z, Val(:Rotation))
     LieGroups.lie_bracket!(LieAlgebra(SOn), Z_R, X_R, Y_R)
     Z_t .= X_R * Y_t .- Y_R * X_t
     return Z

--- a/src/group_operations/multiplication_operation.jl
+++ b/src/group_operations/multiplication_operation.jl
@@ -295,8 +295,7 @@ lie_bracket(::LieAlgebra{𝔽,MatrixMultiplicationGroupOperation}, ::Any, ::Any)
 function lie_bracket!(
     ::LieAlgebra{𝔽,O,<:LieGroup{𝔽,O}}, Z, X, Y
 ) where {𝔽,O<:MatrixMultiplicationGroupOperation}
-    mul!(Z, X, Y)
-    mul!(Z, Y, X, -1, true)
+    Z .= X * Y - Y * X
     return Z
 end
 

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -783,11 +783,31 @@ function Base.:*(
     return SpecialEuclideanMatrixTangentVector(X.value * Y.value)
 end
 
+_doc_lie_bracket_SEn = """
+    lie_bracket(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclideanGroup}, X, Y)
+    lie_bracket!(𝔰𝔢::LieAlgebra{ℝ, SpecialEuclideanGroupOperation, SpecialEuclideanGroup}, Z, X, Y)
+
+Calculate the Lie bracket between elements `X` and `Y` of the Lie algebra of the [`SpecialEuclideanGroup`](@ref).
+For the matrix representation, cf. [`SpecialEuclideanMatrixTangentVector`](@ref) or a `<:AbstractMatrix`, the formula reads
+
+```math
+[X, Y] = XY-YX
+```
+"""
+
+@doc "$(_doc_lie_bracket_SEn)"
+lie_bracket(
+    𝔰𝔢::LieAlgebra{ℝ,<:SpecialEuclideanGroupOperation,<:SpecialEuclideanGroup},
+    X::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+    Y::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+)
+
+@doc "$(_doc_lie_bracket_SEn)"
 function lie_bracket!(
     ::LieAlgebra{ℝ,<:SpecialEuclideanGroupOperation,<:SpecialEuclideanGroup},
-    Z::Union{AbstractMatrix,SpecialEuclideanMatrixTangentVector},
-    X::Union{AbstractMatrix,SpecialEuclideanMatrixTangentVector},
-    Y::Union{AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+    Z::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+    X::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+    Y::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
 )
     # FIXME mul! does not work with SpecialEuclideanMatrixTangentVector
     # mul!(Z, X, Y)

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -809,9 +809,6 @@ function lie_bracket!(
     X::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
     Y::Union{<:AbstractMatrix,SpecialEuclideanMatrixTangentVector},
 )
-    # FIXME mul! does not work with SpecialEuclideanMatrixTangentVector
-    # mul!(Z, X, Y)
-    # mul!(Z, Y, X, -1, true)
     Z .= X * Y - Y * X
     return Z
 end

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -777,6 +777,17 @@ function LinearAlgebra.norm(
     return norm([n1, n2])
 end
 
+function lie_bracket!(
+    ::LieAlgebra{ℝ,<:SpecialEuclideanGroupOperation,<:SpecialEuclideanGroup},
+    Z::AbstractMatrix,
+    X::AbstractMatrix,
+    Y::AbstractMatrix
+)
+    mul!(Z, X, Y)
+    mul!(Z, Y, X, -1, true)
+    return Z
+end
+
 function ManifoldsBase.log!(::SpecialEuclideanGroup, X::AbstractMatrix, g::AbstractMatrix)
     copyto!(X, log(g))
     return X

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -781,7 +781,7 @@ function lie_bracket!(
     ::LieAlgebra{ℝ,<:SpecialEuclideanGroupOperation,<:SpecialEuclideanGroup},
     Z::AbstractMatrix,
     X::AbstractMatrix,
-    Y::AbstractMatrix
+    Y::AbstractMatrix,
 )
     mul!(Z, X, Y)
     mul!(Z, Y, X, -1, true)

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -777,14 +777,22 @@ function LinearAlgebra.norm(
     return norm([n1, n2])
 end
 
+function Base.:*(
+    X::SpecialEuclideanMatrixTangentVector, Y::SpecialEuclideanMatrixTangentVector
+)
+    return SpecialEuclideanMatrixTangentVector(X.value * Y.value)
+end
+
 function lie_bracket!(
     ::LieAlgebra{ℝ,<:SpecialEuclideanGroupOperation,<:SpecialEuclideanGroup},
-    Z::AbstractMatrix,
-    X::AbstractMatrix,
-    Y::AbstractMatrix,
+    Z::Union{AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+    X::Union{AbstractMatrix,SpecialEuclideanMatrixTangentVector},
+    Y::Union{AbstractMatrix,SpecialEuclideanMatrixTangentVector},
 )
-    mul!(Z, X, Y)
-    mul!(Z, Y, X, -1, true)
+    # FIXME mul! does not work with SpecialEuclideanMatrixTangentVector
+    # mul!(Z, X, Y)
+    # mul!(Z, Y, X, -1, true)
+    Z .= X * Y - Y * X
     return Z
 end
 

--- a/test/groups/test_special_euclidean_group.jl
+++ b/test/groups/test_special_euclidean_group.jl
@@ -18,6 +18,7 @@ using StaticArrays
         inv,
         is_flat,
         is_identity,
+        lie_bracket,
         log,
         norm,
         rand,


### PR DESCRIPTION
To close #57 
Moved [lie_bracket from Manifolds.jl](https://github.com/JuliaManifolds/Manifolds.jl/blob/db305e085ae5608310c10a6d19e3524a118b6e81/src/groups/special_euclidean.jl#L804-L825) and updated to fit with LieGroups.jl 

- [x] Needs to be tested
- [x] Fix documentation
- [x] ~Improve duplications: the matrix version is currently duplication of the `lie_bracket` on `MatrixMultiplicationGroupOperation`~