### PR TITLE
Fix compose in CircleGroup(ℝ)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * fix `default_basis` for `LieGroup` to return a `DefaultLieAlgebraOrthogonalBasis` also when providing a point type. That way `get_vector` falls back to the manifold when called with a Lie group and a point, though this is mere a historical format and the Lie algebra approach is the recommended one.
 * mention `get_coordinates`, `get_vector`, `hat`, and `vee` in the transition documentation since it moved to using the `LieAlgebra` instead of the Lie group and a point.
 * Fixed `RightGroupOperationAction` to be a subtype of `AbstractRightGroupActionType`
-* For the CircleGroup(ℝ), fixed compose StackOverflowError and a bug where result could be outside [-π,π), see #62 for detail.
+* For the CircleGroup(ℝ), fixed compose StackOverflowError and a bug where result could be outside [-π,π), see (#62) for detail.
 
 ## [0.1.2] 2025-06-24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * fix `default_basis` for `LieGroup` to return a `DefaultLieAlgebraOrthogonalBasis` also when providing a point type. That way `get_vector` falls back to the manifold when called with a Lie group and a point, though this is mere a historical format and the Lie algebra approach is the recommended one.
 * mention `get_coordinates`, `get_vector`, `hat`, and `vee` in the transition documentation since it moved to using the `LieAlgebra` instead of the Lie group and a point.
 * Fixed `RightGroupOperationAction` to be a subtype of `AbstractRightGroupActionType`
+* For the CircleGroup(ℝ), fixed compose StackOverflowError and a bug where result could be outside [-π,π), see #62 for detail.
 
 ## [0.1.2] 2025-06-24
 

--- a/src/groups/circle_group_real.jl
+++ b/src/groups/circle_group_real.jl
@@ -29,10 +29,10 @@ function _compose(G::_RealCircleGroup, p::AbstractArray{<:Any,0}, q::AbstractArr
     return map((pp, qq) -> compose(G, pp, qq), p, q)
 end
 function _compose(::_RealCircleGroup, p::Number, q::AbstractArray{<:Any,0})
-    return p .+ q
+    return sym_rem(p .+ q)
 end
 function _compose(::_RealCircleGroup, p::AbstractArray{<:Any,0}, q::Number)
-    return p .+ q
+    return sym_rem(p .+ q)
 end
 
 function _compose!(G::_RealCircleGroup, x, p, q)

--- a/src/groups/circle_group_real.jl
+++ b/src/groups/circle_group_real.jl
@@ -18,8 +18,8 @@ Compute symmetric remainder of `x` with respect to the interall 2*`T`, i.e.
 function sym_rem(x::N, T=π) where {N<:Number}
     return (x ≈ T ? convert(N, -T) : rem(x, convert(N, 2 * T), RoundNearest))
 end
-function sym_rem(x, T=π)
-    return map(sym_rem, x, Ref(T))
+function sym_rem(v, T=π)
+    return map(x -> sym_rem(x, T), v)
 end
 
 function _compose(::_RealCircleGroup, p::Number, q::Number)
@@ -28,10 +28,7 @@ end
 function _compose(G::_RealCircleGroup, p::AbstractArray{<:Any,0}, q::AbstractArray{<:Any,0})
     return map((pp, qq) -> compose(G, pp, qq), p, q)
 end
-function _compose(::_RealCircleGroup, p::Number, q::AbstractArray{<:Any,0})
-    return sym_rem(p .+ q)
-end
-function _compose(::_RealCircleGroup, p::AbstractArray{<:Any,0}, q::Number)
+function _compose(::_RealCircleGroup, p, q)
     return sym_rem(p .+ q)
 end
 

--- a/test/groups/test_circle_group.jl
+++ b/test/groups/test_circle_group.jl
@@ -95,11 +95,11 @@ using LieGroupsTestSuite
             @test compose(C2, fill(1.0), 1.0) == 2.0
             @test LieGroups.sym_rem(fill(Float64(π))) == fill(Float64(-π))
             a = -π + 0.1
-            b = -0.2 
-            @test compose(C2, a, b) ==  LieGroups.sym_rem(a + b)
-            @test compose(C2, fill(a), fill(b)) ==  fill(LieGroups.sym_rem(a + b))
-            @test compose(C2, fill(a), b) ==  LieGroups.sym_rem(a + b)
-            @test compose(C2, a, fill(b)) ==  LieGroups.sym_rem(a + b)
+            b = -0.2
+            @test compose(C2, a, b) == LieGroups.sym_rem(a + b)
+            @test compose(C2, fill(a), fill(b)) == fill(LieGroups.sym_rem(a + b))
+            @test compose(C2, fill(a), b) == LieGroups.sym_rem(a + b)
+            @test compose(C2, a, fill(b)) == LieGroups.sym_rem(a + b)
         end
     end
     @testset "Planar Circle" begin

--- a/test/groups/test_circle_group.jl
+++ b/test/groups/test_circle_group.jl
@@ -57,8 +57,8 @@ using LieGroupsTestSuite
         X1, X2, X3 = 1.0, 3.0, -123.0
         properties = Dict(
             :Name => "Array Points and Array Vectors",
-            :Points => [fill(x1), fill(x2), fill(x3)],
-            :Vectors => [fill(X1), fill(X2), fill(X3)],
+            :Points => [fill(x1), fill(x2), fill(x3), [x1], [x2], [x3]],
+            :Vectors => [fill(X1), fill(X2), fill(X3), [X1], [X2], [X3]],
             :Rng => Random.MersenneTwister(),
             :Mutating => true,
             :Functions => [
@@ -94,6 +94,12 @@ using LieGroupsTestSuite
             @test compose(C2, 1.0, fill(1.0)) == 2.0
             @test compose(C2, fill(1.0), 1.0) == 2.0
             @test LieGroups.sym_rem(fill(Float64(π))) == fill(Float64(-π))
+            a = -π + 0.1
+            b = -0.2 
+            @test compose(C2, a, b) ==  LieGroups.sym_rem(a + b)
+            @test compose(C2, fill(a), fill(b)) ==  LieGroups.sym_rem(a + b)
+            @test compose(C2, fill(a), b) ==  LieGroups.sym_rem(a + b)
+            @test compose(C2, a, fill(b)) ==  LieGroups.sym_rem(a + b)
         end
     end
     @testset "Planar Circle" begin

--- a/test/groups/test_circle_group.jl
+++ b/test/groups/test_circle_group.jl
@@ -100,6 +100,15 @@ using LieGroupsTestSuite
             @test compose(C2, fill(a), fill(b)) == fill(LieGroups.sym_rem(a + b))
             @test compose(C2, fill(a), b) == LieGroups.sym_rem(a + b)
             @test compose(C2, a, fill(b)) == LieGroups.sym_rem(a + b)
+            @test compose(C2, [a], [b]) == [LieGroups.sym_rem(a + b)]
+            @test compose(C2, [a], [b]) == [LieGroups.sym_rem(a + b)]
+            c = [0.0]
+            compose!(C2, c, a, b)
+            @test c == [LieGroups.sym_rem(a + b)]
+            compose!(C2, c, [a], b)
+            @test c == [LieGroups.sym_rem(a + b)]
+            compose!(C2, c, [a], [b])
+            @test c == [LieGroups.sym_rem(a + b)]
         end
     end
     @testset "Planar Circle" begin
@@ -143,5 +152,6 @@ using LieGroupsTestSuite
             LieAlgebra(C), SA[2.0], DefaultLieAlgebraOrthogonalBasis(), SVector{1}
         )
         @test a === SA[2.0]
+        @test compose(C, SA[0], SA[π]) == SA[-π]
     end
 end

--- a/test/groups/test_circle_group.jl
+++ b/test/groups/test_circle_group.jl
@@ -97,7 +97,7 @@ using LieGroupsTestSuite
             a = -π + 0.1
             b = -0.2 
             @test compose(C2, a, b) ==  LieGroups.sym_rem(a + b)
-            @test compose(C2, fill(a), fill(b)) ==  LieGroups.sym_rem(a + b)
+            @test compose(C2, fill(a), fill(b)) ==  fill(LieGroups.sym_rem(a + b))
             @test compose(C2, fill(a), b) ==  LieGroups.sym_rem(a + b)
             @test compose(C2, a, fill(b)) ==  LieGroups.sym_rem(a + b)
         end


### PR DESCRIPTION
This fixes a bug with `sym_rem` in compose of the real circle group.

Additionally, I would like to fix this:
```julia
julia> C2 = CircleGroup(ℝ)
CircleGroup(ℝ)

julia> a = -π + 0.1
-3.041592653589793

julia> b = -0.2
-0.2

julia> @test compose(C2, [a], [b]) == [LieGroups.sym_rem(a + b)]
Error During Test at REPL[53]:1
  Test threw exception
  Expression: compose(C2, [a], [b]) == [LieGroups.sym_rem(a + b)]
  StackOverflowError:
  Stacktrace:
       [1] GenericMemory
         @ ./boot.jl:516 [inlined]
       [2] Array
         @ ./boot.jl:578 [inlined]
       [3] similar
         @ ./array.jl:369 [inlined]
       [4] allocate
         @ ~/.julia/packages/ManifoldsBase/nqeOA/src/ManifoldsBase.jl:79 [inlined]
       [5] allocate
         @ ~/.julia/packages/ManifoldsBase/nqeOA/src/ManifoldsBase.jl:93 [inlined]
       [6] allocate_result
         @ ~/.julia/packages/ManifoldsBase/nqeOA/src/ManifoldsBase.jl:178 [inlined]
       [7] allocate_result
         @ ~/.julia/dev/LieGroups/src/interface.jl:927 [inlined]
       [8] _compose(G::LieGroup{ℝ, AdditionGroupOperation, Manifolds.Circle{ℝ}}, g::Vector{Float64}, h::Vector{Float64})
         @ LieGroups ~/.julia/dev/LieGroups/src/interface.jl:208
       [9] compose(G::LieGroup{ℝ, AdditionGroupOperation, Manifolds.Circle{ℝ}}, g::Vector{Float64}, h::Vector{Float64})
         @ LieGroups ~/.julia/dev/LieGroups/src/interface.jl:198
      [10] _compose!(G::LieGroup{ℝ, AdditionGroupOperation, Manifolds.Circle{ℝ}}, x::Vector{Float64}, p::Vector{Float64}, q::Vector{Float64})
         @ LieGroups ~/.julia/dev/LieGroups/src/groups/circle_group_real.jl:39
      [11] _compose(G::LieGroup{ℝ, AdditionGroupOperation, Manifolds.Circle{ℝ}}, g::Vector{Float64}, h::Vector{Float64})
         @ LieGroups ~/.julia/dev/LieGroups/src/interface.jl:209
  --- the above 3 lines are repeated 18553 more times ---
   [55671] compose(G::LieGroup{ℝ, AdditionGroupOperation, Manifolds.Circle{ℝ}}, g::Vector{Float64}, h::Vector{Float64})
         @ LieGroups ~/.julia/dev/LieGroups/src/interface.jl:198
   [55672] macro expansion
         @ ~/.julia/juliaup/julia-1.11.6+0.x64.linux.gnu/share/julia/stdlib/v1.11/Test/src/Test.jl:677 [inlined]
ERROR: There was an error during testing
```

We use vectors in all the current JuliaRobotics packages dependent on Manifolds. In Manifolds.jl's real circle group vectors used to work but I now get his error. 