### PR TITLE
Improve how product and semidirect Lie group constructors act.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed an issue where internally the product manifold in a `SemidirectProductLieGroup` was accidentally splashed
+* make `×` and `ProductLieGroup` behave the same way as `×` and `ProductManifold` do
 * Fixed an issue, where `exp!(G, h, g, X)` would return a wrong result if the input `g`and the output `h`are aliased (#63).
 
 ## [0.1.3] 2025-08-04

--- a/src/groups/product_group.jl
+++ b/src/groups/product_group.jl
@@ -58,14 +58,23 @@ function LinearAlgebra.cross(P1::ProductGroupOperation, P2::ProductGroupOperatio
 end
 
 """
-    ProductLieGroup(G, H, ...)
+    ProductLieGroup(G1, G2, ..., Gn)
 
-Return the [`LieGroup`](@ref) of the product of Lie groups `G` and `H`.
+Return the [`LieGroup`](@ref) of the product of Lie groups `G1`, `G2`, up to `Gn`
+and all following Lie groups.
+This can be considered as a vector of Lie group, where the vector is always
+of the same length as the number of provided Lie Groups.
 
-Alternatively, the short hand `G × H` can be used.
+If none of the Lie groups are product Lie groups themselves,
+this is equivalent to `G1 × G2 × ... × Gn`.
+
+For an example illustrating the differences see [`x`](@ref LinearAlgebra.cross(::LieGroup...)`(::LieGroup...)`.
 """
-function ProductLieGroup(G::LieGroup, H::LieGroup)
-    return LieGroup(G.manifold × H.manifold, G.op × H.op)
+function ProductLieGroup(lie_groups::LieGroup...)
+    return LieGroup(
+        ProductManifold([L.manifold for L in lie_groups]...),
+        ProductGroupOperation([L.op for L in lie_groups]...)
+    )
 end
 
 function ManifoldsBase.submanifold_components(
@@ -127,16 +136,70 @@ end
     G × H
     G1 × G2 × G3 × ...
 
-Return the [`ProductLieGroup`](@ref) For two [`LieGroups`](@ref) `G` and `H`,
-where for the case that one of them is a [`ProductLieGroup`](@ref) itself,
-the other is either prepended (if `H` is a product) or appended (if `G` is).
-If both are product Lie groups, they are combined into one, keeping the order of operations.
+Return the [`ProductLieGroup`](@ref) For two [`LieGroups`](@ref) `G` and `H`.
 
-For the case that more than two are concatenated with `×` this is iterated.
+For the case that one of them is a product Lie group already,
+the other one is appended or prepended, depending on which one is the product;
+they are joined into one large product if both are product Lie groups.
+
+In order to build a [`ProductLieGroup`](@ref) that does not “splat” its arguments,
+or in other words to obtain “nested” products,
+use [`ProductLieGroup`](@ref)`(G1, G2, G3, ...)`.
+
+# Example.
+
+For
+````
+G1 = TranslationGroup(2)
+G2 = SpecialOrthogonalGroup(2)
+G3 = GeneralLinearGroup(2)
+```
+
+We can have one large product Lie group
+
+```
+G = G1 × G2 × G3 # or equivalently ProductLieGroup(G1, G2, G3)
+````
+
+and alternatively generate a product of a Lie group with an exitsing product using
+
+```
+H = ProductLieGroup(G1, G2 × G3)
+```
+
+!!! Note
+    Since for the first, single Lie group, the order should be irrelevant, it means
+    in practice that `×` behaves slightly different than `ProductLieGroup` in that it “splats” its arguments.
+    `G` is equivalent to calling
+    `ProductLieGroup(G1, G2) × G3` or ` G1 × ProductLieGroup(G2, G3)`.
+    Both, as `G` would consist of vectors of length 3.
+
+    These are different from both
+    `ProductLieGroup(ProductLieGroup(G1, G2), G3)` and `ProductLieGroup(G1, ProductLieGroup(G2, G3))`,
+    which are both vectors of length 2, where the first has a vector of length 2 in its first component,
+    the second such a vector in its second component.
 """
 LinearAlgebra.cross(::LieGroup...)
 function LinearAlgebra.cross(G::LieGroup, H::LieGroup)
     return ProductLieGroup(G, H)
+end
+function LinearAlgebra.cross(
+        G::LieGroup{𝔽, Op, M}, H::LieGroup
+    ) where {𝔽, Op <: ProductGroupOperation, M <: ProductManifold}
+    return ProductLieGroup(map(LieGroup, G.manifold.manifolds, G.op.operations)..., H)
+end
+function LinearAlgebra.cross(
+        G::LieGroup, H::LieGroup{𝔽, Op, M}
+    ) where {𝔽, Op <: ProductGroupOperation, M <: ProductManifold}
+    return ProductLieGroup(G, map(LieGroup, H.manifold.manifolds, H.op.operations)...)
+end
+function LinearAlgebra.cross(
+        G::LieGroup{𝔽1, Op1, M1}, H::LieGroup{𝔽2, Op2, M2}
+    ) where {𝔽1, Op1 <: ProductGroupOperation, M1 <: ProductManifold, 𝔽2, Op2 <: ProductGroupOperation, M2 <: ProductManifold}
+    return ProductLieGroup(
+        map(LieGroup, G.manifold.manifolds, G.op.operations)...,
+        map(LieGroup, H.manifold.manifolds, H.op.operations)...
+    )
 end
 
 function diff_conjugate!(

--- a/src/groups/product_group.jl
+++ b/src/groups/product_group.jl
@@ -76,6 +76,11 @@ function ProductLieGroup(lie_groups::LieGroup...)
         ProductGroupOperation([L.op for L in lie_groups]...)
     )
 end
+# Do not “wrap twice”
+function ProductLieGroup(G::LieGroup{𝔽, Op, M}) where {𝔽, Op <: ProductGroupOperation, M <: ProductManifold}
+    return G
+end
+
 
 function ManifoldsBase.submanifold_components(
         ::LieGroup{𝔽, Op, M}, op::ProductGroupOperation
@@ -149,7 +154,7 @@ use [`ProductLieGroup`](@ref)`(G1, G2, G3, ...)`.
 # Example.
 
 For
-````
+```
 G1 = TranslationGroup(2)
 G2 = SpecialOrthogonalGroup(2)
 G3 = GeneralLinearGroup(2)
@@ -159,21 +164,20 @@ We can have one large product Lie group
 
 ```
 G = G1 × G2 × G3 # or equivalently ProductLieGroup(G1, G2, G3)
-````
+```
 
-and alternatively generate a product of a Lie group with an exitsing product using
+and alternatively generate a product of a Lie group with an existing product using
 
 ```
 H = ProductLieGroup(G1, G2 × G3)
 ```
 
-!!! Note
+!!! note "Technical detail"
     Since for the first, single Lie group, the order should be irrelevant, it means
     in practice that `×` behaves slightly different than `ProductLieGroup` in that it “splats” its arguments.
     `G` is equivalent to calling
     `ProductLieGroup(G1, G2) × G3` or ` G1 × ProductLieGroup(G2, G3)`.
     Both, as `G` would consist of vectors of length 3.
-
     These are different from both
     `ProductLieGroup(ProductLieGroup(G1, G2), G3)` and `ProductLieGroup(G1, ProductLieGroup(G2, G3))`,
     which are both vectors of length 2, where the first has a vector of length 2 in its first component,

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -126,8 +126,9 @@ corresponding [`default_left_action`](@ref)`(N,H)` is the one you want to use.
 function LeftSemidirectProductLieGroup(
         N::LieGroup, H::LieGroup, action::AbstractGroupActionType = default_left_action(N, H)
     )
+    # Use product manifold instead of × to not accidentally splat.
     return LieGroup(
-        N.manifold × H.manifold, LeftSemidirectProductGroupOperation(N.op, H.op, action)
+        ProductManifold(N.manifold, H.manifold), LeftSemidirectProductGroupOperation(N.op, H.op, action)
     )
 end
 
@@ -146,8 +147,9 @@ corresponding [`default_right_action`](@ref)`(N,H)` is the one you want to use.
 function RightSemidirectProductLieGroup(
         N::LieGroup, H::LieGroup, action::AbstractGroupActionType = default_right_action(N, H)
     )
+    # Use product manifold instead of × to not accidentally splat.
     return LieGroup(
-        N.manifold × H.manifold, RightSemidirectProductGroupOperation(N.op, H.op, action)
+        ProductManifold(N.manifold, H.manifold), RightSemidirectProductGroupOperation(N.op, H.op, action)
     )
 end
 

--- a/test/groups/test_product_group.jl
+++ b/test/groups/test_product_group.jl
@@ -66,5 +66,7 @@ using LieGroupsTestSuite
         @test G3 × G == H
         @test G × G3 == H
         @test G2 × G2 == H
+        # Check constructor for more than 2 Lie groups
+        @test ProductLieGroup(G, G, G, G) == H
     end
 end

--- a/test/groups/test_product_group.jl
+++ b/test/groups/test_product_group.jl
@@ -42,10 +42,10 @@ using LieGroupsTestSuite
         @test ManifoldsBase.check_size(G, Identity(G)) == nothing
         @test ManifoldsBase.check_size(G, Identity(G), X) == nothing
     end
-    @testset "Special dispatch cass for log" begin end
     @testset "Product Operation generators" begin
         G = LieGroupsTestSuite.DummyLieGroup()
         G2 = G × G
+        @test ProductLieGroup(G2) === G2 #Product groups are not “wrapped twice”
         op = LieGroupsTestSuite.DummyOperation()
         op2 = LieGroupsTestSuite.DummySecondOperation()
         O1 = op × op2
@@ -56,5 +56,15 @@ using LieGroupsTestSuite
         @test O1[2] == op2
         @test O1[:] == (op, op2)
         @test O1[:] == LieGroups.submanifold_components(G2, O1)
+    end
+    @testset "× splashes" begin
+        G = LieGroupsTestSuite.DummyLieGroup()
+        G2 = G × G
+        G3 = G × G × G
+        H = G × G × G × G
+        # one or two products in cross -> splat.
+        @test G3 × G == H
+        @test G × G3 == H
+        @test G2 × G2 == H
     end
 end

--- a/test/groups/test_semidirect_product_group.jl
+++ b/test/groups/test_semidirect_product_group.jl
@@ -69,4 +69,21 @@ using LieGroupsTestSuite
         )
         test_lie_group(Gr, properties, expectations_r)
     end
+    @testset "Interaction os semidirect and product" begin
+        M = LieGroupsTestSuite.DummyManifold()
+        op1 = LieGroupsTestSuite.DummyOperation()
+        G1 = LieGroup(M, op1)
+        op2 = LieGroupsTestSuite.DummySecondOperation()
+        G2 = LieGroup(M, op2)
+
+
+        Gl = LeftSemidirectProductLieGroup(G1 × G2, G2 × G1, LeftGroupOperationAction())
+        @test Gl.manifold isa ProductManifold
+        @test length(Gl.manifold.manifolds) == 2 # we still just have 2 manifolds, those of the semiproduct
+        # And it is a product of products
+        @test Gl.manifold.manifolds[1] isa ProductManifold
+        @test Gl.manifold.manifolds[2] isa ProductManifold
+        @test Gl.manifold.manifolds[1].manifolds[1] === G1.manifold
+        @test Gl.manifold.manifolds[2].manifolds[1] === G2.manifold
+    end
 end


### PR DESCRIPTION
For Product manifolds we currently have the following behaviour

```{julia-repl}
julia> using Manifolds

julia> M1 = Sphere(2); M2 = Euclidean(2); M3 = SymmetricPositiveDefinite(2)
SymmetricPositiveDefinite(2)

julia> M1 × M2 × M3
ProductManifold with 3 submanifolds:
 Sphere(2, ℝ)
 Euclidean(2; field=ℝ)
 SymmetricPositiveDefinite(2)

julia> ProductManifold(M1, M2, M3)
ProductManifold with 3 submanifolds:
 Sphere(2, ℝ)
 Euclidean(2; field=ℝ)
 SymmetricPositiveDefinite(2)

julia> ProductManifold(M1, ProductManifold(M2,M3))
ProductManifold with 2 submanifolds:
 Sphere(2, ℝ)
 ProductManifold(Euclidean(2; field=ℝ), SymmetricPositiveDefinite(2))
```
where the first also implies that both

```{julia-repl}
julia> M1 × ProductManifold(M2,M3)
ProductManifold with 3 submanifolds:
 Sphere(2, ℝ)
 Euclidean(2; field=ℝ)
 SymmetricPositiveDefinite(2)
julia> ProductManifold(M1, M2) × M3
ProductManifold with 3 submanifolds:
 Sphere(2, ℝ)
 Euclidean(2; field=ℝ)
 SymmetricPositiveDefinite(2)
```

or in other words: `×` always “splats” its involved Product manifolds, while the direct constructor does not. This allows to produce both results.

This PR aims to provide the same for the `ProductLieGroup` both to be consistent and to be able to generate both the direct product of multiple Lie groups as well as the “nested” variant.

* [x] `G1 × G2 × G3` works (already before the PR)
* [x]  `ProductLieGroup(G1, G2, G3)`should produce the same (before the PR it errored)
* [x] bsted cases like `ProductLieGroup(G1, ProductLieGroup(G2,G3))`(already before)
* [x] `ProductLieGroup(G1,G2) × G3` and `G1 × ProductLieGroup(G1,G2)` work as in the second block (`×` “splats”)
* [x] check interoperability with the semidirect one, that that not accidentally “splats” but keeps a product of exactly 2.
* [x] add tests for points 2 and 5 of this list.

For the last point, before this PR, it used `×` which as shown above is the wrong one internally, since it shuld not “splat” the two parts of the semidirect product but really just have a product of two.
