### PR TITLE
Test 8 Semidirect Product combinations, add compose associativity test, and fix compose alias bug

### DIFF
--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -303,7 +303,7 @@ function _compose!(
         SDPG::LieGroup{𝔽, <:SemidirectProductGroupOperation{O1, O2, A, AO}, <:ProductManifold}, k, g, h
     ) where {𝔽, O1, O2, A <: AbstractGroupActionType, AO <: ActionActsOnLeft}
     PM, G, H, a, g_ind, h_ind = _semidirect_parts(SDPG)
-    if Base.mightalias(k, g) || Base.mightalias(h, g) || Base.mightalias(k, h)# k/h may not overlap with g
+    if Base.mightalias(k, g) || Base.mightalias(h, g) || Base.mightalias(k, h) # k/h may not overlap with g
         kH = copy(H, submanifold_component(SDPG, k, Val(h_ind))) # to
     else # if it does not alias, we can just use kG & kH
         kH = submanifold_component(SDPG, k, Val(h_ind))

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -303,7 +303,7 @@ function _compose!(
         SDPG::LieGroup{𝔽, <:SemidirectProductGroupOperation{O1, O2, A, AO}, <:ProductManifold}, k, g, h
     ) where {𝔽, O1, O2, A <: AbstractGroupActionType, AO <: ActionActsOnLeft}
     PM, G, H, a, g_ind, h_ind = _semidirect_parts(SDPG)
-    if Base.mightalias(k, g) || Base.mightalias(h, g) # k/h may not overlap with g
+    if Base.mightalias(k, g) || Base.mightalias(h, g) || Base.mightalias(k, h)# k/h may not overlap with g
         kH = copy(H, submanifold_component(SDPG, k, Val(h_ind))) # to
     else # if it does not alias, we can just use kG & kH
         kH = submanifold_component(SDPG, k, Val(h_ind))

--- a/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
+++ b/test/LieGroupsTestSuite.jl/LieGroupsTestSuite.jl
@@ -146,6 +146,12 @@ function test_compose(
     )
     @testset "compose" begin
         k1 = compose(G, g, h)
+
+        #test associativity
+        a1 = compose(G, compose(G, g, k1), h)
+        a2 = compose(G, g, compose(G, k1, h))
+        @test isapprox(G, a1, a2; atol = atol)
+
         if test_mutating
             k2 = copy(G, g)
             compose!(G, k2, g, h)

--- a/test/groups/test_semidirect_product_group.jl
+++ b/test/groups/test_semidirect_product_group.jl
@@ -56,19 +56,12 @@ using LieGroupsTestSuite
     @testset "8 combinations with (SO(2), ℝ²)" begin
         struct TestLeftAction <: AbstractLeftGroupActionType end
         function LieGroups.apply!(A::GroupAction{TestLeftAction}, k, g, h)
-            @assert is_point(A.manifold, h) "$h not on $(A.manifold)"
-            @assert is_point(A.group, g) "$g not on $(A.group)"
-            @assert is_point(A.manifold, g * h) "$(g * h) not on $(A.manifold)"
             return k .= g * h
         end
 
         struct TestRightAction <: AbstractRightGroupActionType end
         function LieGroups.apply!(A::GroupAction{TestRightAction}, k, g, h)
-            @assert is_point(A.manifold, h) "$h not on $(A.manifold)"
-            @assert is_point(A.group, g) "$g not on $(A.group)"
-            @assert is_point(A.manifold, g * h) "$(g * h) not on $(A.manifold)"
-            return k .= inv(A.group, g) * h
-            # return k .= (h' * g)'
+            return k .= inv(A.group, g) * h # (h' * g)'
         end
 
         g1 = 1 / sqrt(2) * [1.0 1.0; -1.0 1.0]

--- a/test/groups/test_semidirect_product_group.jl
+++ b/test/groups/test_semidirect_product_group.jl
@@ -53,4 +53,59 @@ using LieGroupsTestSuite
         @test Gl.manifold.manifolds[1].manifolds[1] === G1.manifold
         @test Gl.manifold.manifolds[2].manifolds[1] === G2.manifold
     end
+    @testset "8 combinations with (SO(2), ℝ²)" begin
+        struct TestLeftAction <: AbstractLeftGroupActionType end
+        function LieGroups.apply!(A::GroupAction{TestLeftAction}, k, g, h)
+            @assert is_point(A.manifold, h) "$h not on $(A.manifold)"
+            @assert is_point(A.group, g) "$g not on $(A.group)"
+            @assert is_point(A.manifold, g * h) "$(g * h) not on $(A.manifold)"
+            return k .= g * h
+        end
+
+        struct TestRightAction <: AbstractRightGroupActionType end
+        function LieGroups.apply!(A::GroupAction{TestRightAction}, k, g, h)
+            @assert is_point(A.manifold, h) "$h not on $(A.manifold)"
+            @assert is_point(A.group, g) "$g not on $(A.group)"
+            @assert is_point(A.manifold, g * h) "$(g * h) not on $(A.manifold)"
+            return k .= inv(A.group, g) * h
+            # return k .= (h' * g)'
+        end
+
+        g1 = 1 / sqrt(2) * [1.0 1.0; -1.0 1.0]
+        g2 = [0.0 -1.0; 1.0 0.0]
+        g3 = [1.0 0.0; 0.0 1.0]
+        h1 = [0.1, 0.1]
+        h2 = [0.0, 1.0]
+        h3 = [0.0, 0]
+
+        for action in (TestLeftAction(), TestRightAction()),
+            action_on in (ActionActsOnLeft(), ActionActsOnRight())
+
+            G = LeftSemidirectProductLieGroup(SpecialOrthogonalGroup(2), TranslationGroup(2), action; action_on)
+            p1 = ArrayPartition(copy(g1), copy(h1))
+            p2 = ArrayPartition(copy(g2), copy(h2))
+            p3 = ArrayPartition(copy(g3), copy(h3))
+
+            properties = Dict(
+                :Name => "LeftSemidirectProductLieGroup, $(supertype(typeof(action))), $(action_on)",
+                :Points => [p1, p2, p3],
+                :Functions => [identity_element, is_identity, inv, compose, show],
+            )
+            expectations = Dict(:atol => 1.0e-14)
+
+            test_lie_group(G, properties, expectations)
+
+            G = RightSemidirectProductLieGroup(TranslationGroup(2), SpecialOrthogonalGroup(2), action; action_on)
+            p1 = ArrayPartition(copy(h1), copy(g1))
+            p2 = ArrayPartition(copy(h2), copy(g2))
+            p3 = ArrayPartition(copy(h3), copy(g3))
+            properties = Dict(
+                :Name => "RightSemidirectProductLieGroup, $(supertype(typeof(action))), $(action_on)",
+                :Points => [p1, p2, p3],
+                :Functions => [identity_element, is_identity, inv, compose, show],
+            )
+            expectations = Dict(:atol => 1.0e-14)
+            test_lie_group(G, properties, expectations)
+        end
+    end
 end

--- a/test/groups/test_semidirect_product_group.jl
+++ b/test/groups/test_semidirect_product_group.jl
@@ -79,7 +79,7 @@ using LieGroupsTestSuite
         h3 = [0.0, 0]
 
         for action in (TestLeftAction(), TestRightAction()),
-            action_on in (ActionActsOnLeft(), ActionActsOnRight())
+                action_on in (ActionActsOnLeft(), ActionActsOnRight())
 
             G = LeftSemidirectProductLieGroup(SpecialOrthogonalGroup(2), TranslationGroup(2), action; action_on)
             p1 = ArrayPartition(copy(g1), copy(h1))


### PR DESCRIPTION
@kellertuer, I made this PR against #67 (note base branch) in case you want to add this way of testing the 8 combinations of Semidirect product groups. 
Feel free to just close this if you have other tests in mind.