### PR TITLE
Fix zenodo.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,7 +3,8 @@
         {
             "affiliation": "WhereWhen.ai Technologies Inc.",
             "name": "Terblanche, Johannes",
-            "orcid": "0009-0002-5720-5616"
+            "orcid": "0009-0002-5720-5616",
+            "type": "ProjectMember"
         }
     ],
     "creators": [


### PR DESCRIPTION
We had a missing type for the contributor; this fixes it, so we should get (after missing 0.1.4, 0.1.5, 0.1.6) at least for 0.1.7 a new zenodo entry. 

I would prefer to have a feature to make such a release useful but also not to wait too long to have a working recent DOI again.