### PR TITLE
Fix allocation in the `SpecialEuclideanGroup` constructor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable Changes to the Julia package `LieGroups.jl` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed allocations in the `SpecialEuclideanGroup` constructor.
+
 ## [0.1.10] 2026-04-18
 
 ### Fixed

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -178,7 +178,7 @@ end
 function SpecialEuclideanGroup(n::Int; variant::Symbol = :left, kwargs...)
     SOn = SpecialOrthogonalGroup(n; kwargs...)
     Tn = TranslationGroup(n; kwargs...)
-    variant ∉ SA[:left, :right] && error(
+    variant ∉ (:left, :right) && error(
         "SE(n) requires a  variant ∉ [:left, :right] but you provided `variant=:$variant`",
     )
     return variant === :left ? SOn ⋉ Tn : Tn ⋊ SOn

--- a/src/groups/special_euclidean_group.jl
+++ b/src/groups/special_euclidean_group.jl
@@ -178,7 +178,7 @@ end
 function SpecialEuclideanGroup(n::Int; variant::Symbol = :left, kwargs...)
     SOn = SpecialOrthogonalGroup(n; kwargs...)
     Tn = TranslationGroup(n; kwargs...)
-    variant ∉ [:left, :right] && error(
+    variant ∉ SA[:left, :right] && error(
         "SE(n) requires a  variant ∉ [:left, :right] but you provided `variant=:$variant`",
     )
     return variant === :left ? SOn ⋉ Tn : Tn ⋊ SOn


### PR DESCRIPTION
Strangely, this caused dynamic dispatch and other allocations in the `TranslationGroup` and `RotationsGroup` constructors that doubled my solve time with RLM, but this fixed cleared that up.
Before and after:
```julia
julia> @btime SpecialEuclideanGroup(2)
  1.577 μs (15 allocations: 720 bytes)
SpecialEuclideanGroup(2)

julia> @btime SpecialEuclideanGroup(2)
  1.148 ns (0 allocations: 0 bytes)
SpecialEuclideanGroup(2)
```